### PR TITLE
Synchronize plugin version constant

### DIFF
--- a/theme-export-jlg/theme-export-jlg.php
+++ b/theme-export-jlg/theme-export-jlg.php
@@ -18,7 +18,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Définir les constantes utiles du plugin
-define( 'TEJLG_VERSION', '2.2.0' );
+$plugin_data = get_file_data( __FILE__, [ 'Version' => 'Version' ] );
+define( 'TEJLG_VERSION', ! empty( $plugin_data['Version'] ) ? $plugin_data['Version'] : '1.0.0' );
 define( 'TEJLG_PATH', plugin_dir_path( __FILE__ ) );
 define( 'TEJLG_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
## Summary
- load the plugin header metadata to derive TEJLG_VERSION dynamically so it always matches the declared plugin version
- keep asset enqueues relying on the version constant automatically aligned with the header version

## Testing
- php -l theme-export-jlg/theme-export-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c9dae58b08832e8252dc3a740d010a