### PR TITLE
Handle missing mbstring in pattern export sanitization

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -104,7 +104,15 @@ class TEJLG_Export {
      */
     private static function get_sanitized_content() {
         $content = get_the_content();
-        return mb_convert_encoding($content, 'UTF-8', 'UTF-8');
+        if (function_exists('mb_convert_encoding')) {
+            return mb_convert_encoding($content, 'UTF-8', 'UTF-8');
+        }
+
+        if (function_exists('wp_check_invalid_utf8')) {
+            return wp_check_invalid_utf8($content, true);
+        }
+
+        return (string) $content;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a mb_convert_encoding availability check before sanitizing exported pattern content
- fall back to wp_check_invalid_utf8 or a safe string cast when mbstring is unavailable

## Testing
- php -l theme-export-jlg/includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68c9dae6c404832ebed20754a65460ff