### PR TITLE
Fix portable export media id replacement

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -123,7 +123,7 @@ class TEJLG_Export {
         $content = str_replace(get_home_url(), '', $content);
 
         // 2. Neutralise les IDs des médias pour éviter les dépendances
-        $content = preg_replace('/("id"\s*:\s*)\d+/', '$1' . '0', $content);
+        $content = preg_replace('/("id"\s*:\s*)\d+/', '${1}0', $content);
 
         // 3. Supprime les métadonnées potentiellement incompatibles
         $content = preg_replace('/,\s*"metadata"\s*:\s*\{[^{}]*?\}/s', '', $content);


### PR DESCRIPTION
## Summary
- ensure the regex replacement for media ids keeps the captured prefix when neutralizing ids in portable exports

## Testing
- php -l includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68cadca3c084832e831bd2a751ab6f2d