### PR TITLE
Sanitize pattern preview markup

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -279,9 +279,9 @@ class TEJLG_Admin {
                 <?php foreach ($patterns as $index => $pattern): ?>
                     <?php
                     $pattern_content = isset($pattern['content']) ? (string) $pattern['content'] : '';
-                    $sanitized_pattern_content = wp_kses_post($pattern_content);
-                    $rendered_pattern = do_blocks($sanitized_pattern_content);
-                    $iframe_content = '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0"><style>' . $global_styles . '</style></head><body class="block-editor-writing-flow">' . $rendered_pattern . '</body></html>';
+                    $rendered_pattern = do_blocks($pattern_content);
+                    $sanitized_rendered_pattern = wp_kses_post($rendered_pattern);
+                    $iframe_content = '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0"><style>' . $global_styles . '</style></head><body class="block-editor-writing-flow">' . $sanitized_rendered_pattern . '</body></html>';
                     ?>
                     <div class="pattern-item">
                         <div class="pattern-selector">


### PR DESCRIPTION
## Summary
- sanitize the rendered pattern markup with `wp_kses_post` before embedding it in the preview iframe to strip active tags
- ensure the iframe remains sandboxed without script execution privileges

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68caf5e964c4832e8a637a8f771a36fb