### PR TITLE
Align pattern slugs across export and import

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -53,9 +53,14 @@ class TEJLG_Export {
                 if ($is_portable) {
                     $content = self::clean_pattern_content($content);
                 }
+                $slug = get_post_field('post_name', get_the_ID());
+                if ('' === $slug) {
+                    $slug = sanitize_title(get_the_title());
+                }
+
                 $all_patterns[] = [
                     'title'   => get_the_title(),
-                    'slug'    => 'custom-patterns/' . sanitize_title(get_the_title()),
+                    'slug'    => $slug,
                     'content' => $content,
                 ];
             }
@@ -87,9 +92,14 @@ class TEJLG_Export {
                 if ($is_portable) {
                     $content = self::clean_pattern_content($content);
                 }
+                $slug = get_post_field('post_name', get_the_ID());
+                if ('' === $slug) {
+                    $slug = sanitize_title(get_the_title());
+                }
+
                 $selected_patterns[] = [
                     'title'   => get_the_title(),
-                    'slug'    => 'custom-patterns/' . sanitize_title(get_the_title()),
+                    'slug'    => $slug,
                     'content' => $content,
                 ];
             }

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -59,7 +59,14 @@ class TEJLG_Import {
 
             $pattern = $all_patterns[$index];
 
-            $slug = isset($pattern['slug']) ? sanitize_title($pattern['slug']) : '';
+            $raw_slug = isset($pattern['slug']) ? (string) $pattern['slug'] : '';
+            $raw_slug = trim($raw_slug);
+
+            if (0 === strpos($raw_slug, 'custom-patterns/')) {
+                $raw_slug = substr($raw_slug, strlen('custom-patterns/'));
+            }
+
+            $slug = sanitize_title($raw_slug);
             if ('' === $slug) {
                 $errors[] = sprintf('La composition à l\'index %d ne possède pas de slug valide.', $index);
                 continue;


### PR DESCRIPTION
## Summary
- export block patterns using their actual post slugs for both full and selective exports, falling back to a sanitized title when missing
- normalize imported slugs by dropping legacy custom-patterns/ prefixes before sanitation to match updated exports

## Testing
- php -l theme-export-jlg/includes/class-tejlg-export.php
- php -l theme-export-jlg/includes/class-tejlg-import.php

------
https://chatgpt.com/codex/tasks/task_e_68cb0182dc2c832e90a94edaa714c99e