### PR TITLE
Validate selected patterns before import

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -51,7 +51,7 @@ class TEJLG_Admin {
 
         // Import Compositions (Étape 2)
         if (isset($_POST['tejlg_import_patterns_step2_nonce']) && wp_verify_nonce($_POST['tejlg_import_patterns_step2_nonce'], 'tejlg_import_patterns_step2_action')) {
-            if (isset($_POST['transient_id']) && isset($_POST['selected_patterns'])) {
+            if (isset($_POST['transient_id']) && isset($_POST['selected_patterns']) && is_array($_POST['selected_patterns'])) {
                 TEJLG_Import::handle_patterns_import_step2(sanitize_key($_POST['transient_id']), $_POST['selected_patterns']);
             }
         }

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -46,8 +46,13 @@ class TEJLG_Import {
             return;
         }
 
+        if (!is_array($selected_indices)) {
+            add_settings_error('tejlg_import_messages', 'patterns_import_status', 'Erreur : La sélection des compositions est invalide.', 'error');
+            return;
+        }
+
         delete_transient($transient_id);
-        
+
         $imported_count = 0;
         $errors = [];
 


### PR DESCRIPTION
## Summary
- ensure the selected patterns post data is an array before invoking the import step
- guard the import routine against invalid selections and surface an admin error message

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php
- php -l theme-export-jlg/includes/class-tejlg-import.php

------
https://chatgpt.com/codex/tasks/task_e_68cb16347c44832e8e3f6a16b7db34b5