### PR TITLE
Escape transient prefix in uninstall cleanup

### DIFF
--- a/theme-export-jlg/uninstall.php
+++ b/theme-export-jlg/uninstall.php
@@ -21,8 +21,9 @@ $transient_prefix = 'tejlg_';
 
 // Préparer les motifs de recherche pour les transients. WordPress stocke les transients
 // sous deux entrées dans la table wp_options : une pour la donnée et une pour son délai d'expiration.
-$transient_pattern = '_transient_' . $transient_prefix . '%';
-$timeout_pattern = '_transient_timeout_' . $transient_prefix . '%';
+$escaped_transient_prefix = $wpdb->esc_like( $transient_prefix );
+$transient_pattern        = '_transient_' . $escaped_transient_prefix . '%';
+$timeout_pattern          = '_transient_timeout_' . $escaped_transient_prefix . '%';
 
 // Exécuter une requête SQL directe pour supprimer toutes les options qui correspondent à nos motifs.
 // C'est la méthode la plus efficace pour supprimer des transients par lot.


### PR DESCRIPTION
## Summary
- escape the transient prefix before building LIKE patterns in the uninstall script
- rebuild the transient patterns with the escaped prefix to ensure only plugin transients are targeted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc49334368832e95687c054c13a9f9