### PR TITLE
Use raw post content for pattern export

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -100,7 +100,7 @@ class TEJLG_Export {
      * Récupère le contenu et garantit qu'il est en UTF-8 valide.
      */
     private static function get_sanitized_content() {
-        $content = get_the_content();
+        $content = get_post_field('post_content', get_the_ID());
         if (function_exists('mb_convert_encoding')) {
             return mb_convert_encoding($content, 'UTF-8', 'UTF-8');
         }


### PR DESCRIPTION
## Summary
- load block content directly from the post_content field instead of using the the_content filter
- keep existing UTF-8 validation on the raw content before returning it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc49329458832eb59dc018a82434cc