### PR TITLE
Normalize child theme function prefix

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-theme-tools.php
+++ b/theme-export-jlg/includes/class-tejlg-theme-tools.php
@@ -54,7 +54,13 @@ class TEJLG_Theme_Tools {
 
         $css_content = implode("\n", $css_lines);
 
-        $function_name_prefix   = str_replace( '-', '_', $child_slug );
+        $function_name_prefix   = preg_replace( '/[^A-Za-z0-9_]/', '_', $child_slug );
+        if ( '' === $function_name_prefix ) {
+            $function_name_prefix = 'tejlg_child_theme';
+        }
+        if ( ! preg_match( '/^[A-Za-z_]/', $function_name_prefix ) ) {
+            $function_name_prefix = 'tejlg_' . $function_name_prefix;
+        }
         $sanitized_stylesheet   = sanitize_key( $parent_theme->get_stylesheet() );
         $php_content = sprintf(
 '<?php


### PR DESCRIPTION
## Summary
- ensure the generated child theme function prefix only uses safe characters and always starts with a letter or underscore
- continue passing the sanitized prefix into the generated functions.php template

## Testing
- php /tmp/test_child_theme.php
- php -l /tmp/tejlg_test_theme_root/123-sample-child-theme/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6ca9a7ac832e9260b8e2d5c67d73