### PR TITLE
Prevent unauthorized theme imports

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -45,7 +45,14 @@ class TEJLG_Admin {
         
         // Import Thème
         if (isset($_POST['tejlg_import_theme_nonce']) && wp_verify_nonce($_POST['tejlg_import_theme_nonce'], 'tejlg_import_theme_action')) {
-            if (isset($_FILES['theme_zip']) && $_FILES['theme_zip']['error'] === UPLOAD_ERR_OK) {
+            if (!current_user_can('install_themes')) {
+                add_settings_error(
+                    'tejlg_import_messages',
+                    'theme_import_permissions',
+                    esc_html__('Vous n’avez pas l’autorisation d’installer des thèmes sur ce site.', 'theme-export-jlg'),
+                    'error'
+                );
+            } elseif (isset($_FILES['theme_zip']) && $_FILES['theme_zip']['error'] === UPLOAD_ERR_OK) {
                 TEJLG_Import::import_theme($_FILES['theme_zip']);
             }
         }

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -2,6 +2,17 @@
 class TEJLG_Import {
 
     public static function import_theme($file) {
+        if (!current_user_can('install_themes')) {
+            add_settings_error(
+                'tejlg_import_messages',
+                'theme_import_permissions',
+                esc_html__('Vous n’avez pas l’autorisation d’installer des thèmes sur ce site.', 'theme-export-jlg'),
+                'error'
+            );
+
+            return;
+        }
+
         require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
         require_once ABSPATH . 'wp-admin/includes/file.php';
 


### PR DESCRIPTION
## Summary
- add a capability check to `TEJLG_Import::import_theme()` so unauthorized users receive a clear error instead of triggering an installation
- short-circuit the admin form handler with the same message when the user lacks the `install_themes` capability

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cd6b4f4ff0832eb7e2e6c070e48b1d