### PR TITLE
Add capability guard for theme import

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -49,7 +49,7 @@ class TEJLG_Admin {
                 add_settings_error(
                     'tejlg_import_messages',
                     'theme_import_cap_missing',
-                    esc_html__('Erreur : vous n\'avez pas les permissions nécessaires pour installer des thèmes.', 'theme-export-jlg'),
+                    esc_html__('Vous n\'avez pas l\'autorisation d\'installer des thèmes sur ce site.', 'theme-export-jlg'),
                     'error'
                 );
             } elseif (isset($_FILES['theme_zip']) && $_FILES['theme_zip']['error'] === UPLOAD_ERR_OK) {

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -10,7 +10,7 @@ class TEJLG_Import {
             add_settings_error(
                 'tejlg_import_messages',
                 'theme_import_cap_missing',
-                esc_html__('Erreur : vous n\'avez pas les permissions nécessaires pour installer des thèmes.', 'theme-export-jlg'),
+                esc_html__('Vous n\'avez pas l\'autorisation d\'installer des thèmes sur ce site.', 'theme-export-jlg'),
                 'error'
             );
 


### PR DESCRIPTION
## Summary
- align the unauthorized theme import notice with the plugin translation domain and wording in both admin handling and importer logic

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7594cd98832ea3f83fb481c1bf13