### PR TITLE
Use wp_json_encode with compatible options

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -133,10 +133,16 @@ class TEJLG_Export {
      * Gère la création et le téléchargement du fichier JSON.
      */
     private static function download_json( $data, $filename = 'exported-patterns.json' ) {
-        $json_data = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+        $json_options = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE;
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            $json_error_message = json_last_error_msg();
+        if (defined('JSON_INVALID_UTF8_SUBSTITUTE')) {
+            $json_options |= JSON_INVALID_UTF8_SUBSTITUTE;
+        }
+
+        $json_data = wp_json_encode($data, $json_options);
+
+        if (false === $json_data || (function_exists('json_last_error') && json_last_error() !== JSON_ERROR_NONE)) {
+            $json_error_message = function_exists('json_last_error_msg') ? json_last_error_msg() : __('Erreur JSON inconnue.', 'theme-export-jlg');
 
             wp_die(
                 esc_html(


### PR DESCRIPTION
## Summary
- replace json_encode by wp_json_encode for pattern export
- guard JSON_INVALID_UTF8_SUBSTITUTE constant usage to support PHP 7.0/7.1
- keep detailed error reporting when JSON encoding fails

## Testing
- php -l includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68cd8c3b0fb4832ea25e131c78132eb9