### PR TITLE
Localize admin script strings

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -1,9 +1,12 @@
 document.addEventListener('DOMContentLoaded', function() {
 
-    const localization = window.tejlgAdminL10n || {};
-    const showBlockCodeText = typeof localization.showBlockCode === 'string' ? localization.showBlockCode : '';
-    const hideBlockCodeText = typeof localization.hideBlockCode === 'string' ? localization.hideBlockCode : '';
-    const themeImportConfirmMessage = typeof localization.themeImportConfirm === 'string' ? localization.themeImportConfirm : '';
+    const {
+        showBlockCode: showBlockCodeText = '',
+        hideBlockCode: hideBlockCodeText = '',
+        themeImportConfirm: themeImportConfirmMessage = '',
+    } = (typeof window.tejlgAdminL10n === 'object' && window.tejlgAdminL10n !== null)
+        ? window.tejlgAdminL10n
+        : {};
 
     // Gérer la case "Tout sélectionner" pour l'import
     const selectAllCheckbox = document.getElementById('select-all-patterns');
@@ -58,9 +61,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Gérer la confirmation d'importation de thème
     const themeImportForm = document.getElementById('tejlg-import-theme-form');
-    if (themeImportForm) {
+    if (themeImportForm && themeImportConfirmMessage) {
         themeImportForm.addEventListener('submit', function(event) {
-            if (!confirm(themeImportConfirmMessage)) {
+            if (!window.confirm(themeImportConfirmMessage)) {
                 event.preventDefault();
             }
         });

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -29,8 +29,9 @@ class TEJLG_Admin {
             'tejlg-admin-scripts',
             'tejlgAdminL10n',
             [
-                'showBlockCode'      => esc_html__('Afficher le code du bloc', 'theme-export-jlg'),
-                'hideBlockCode'      => esc_html__('Masquer le code du bloc', 'theme-export-jlg'),
+                'showBlockCode' => esc_html__('Afficher le code du bloc', 'theme-export-jlg'),
+                'hideBlockCode' => esc_html__('Masquer le code du bloc', 'theme-export-jlg'),
+                /* translators: Warning shown before importing a theme zip file. */
                 'themeImportConfirm' => __("⚠️ ATTENTION ⚠️\n\nSi un thème avec le même nom de dossier existe déjà, il sera DÉFINITIVEMENT écrasé.\n\nÊtes-vous sûr de vouloir continuer ?", 'theme-export-jlg'),
             ]
         );

--- a/theme-export-jlg/languages/theme-export-jlg.pot
+++ b/theme-export-jlg/languages/theme-export-jlg.pot
@@ -41,7 +41,7 @@ msgid "Theme Export"
 msgstr ""
 
 #: includes/class-tejlg-admin.php:32
-#: includes/class-tejlg-admin.php:477
+#: includes/class-tejlg-admin.php:478
 msgid "Afficher le code du bloc"
 msgstr ""
 
@@ -49,7 +49,8 @@ msgstr ""
 msgid "Masquer le code du bloc"
 msgstr ""
 
-#: includes/class-tejlg-admin.php:34
+#. translators: Warning shown before importing a theme zip file.
+#: includes/class-tejlg-admin.php:35
 msgid ""
 "⚠️ ATTENTION ⚠️\n"
 "\n"


### PR DESCRIPTION
## Summary
- expose the admin script UI strings to JavaScript through `wp_localize_script()` with proper translator context
- consume the localized strings in the admin JavaScript with safe fallbacks before updating button text or running confirmations
- refresh the POT catalog to include the new translator comment and updated references

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb96605a8832e8410041927567981