### PR TITLE
Improve admin localization safety

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -1,12 +1,20 @@
 document.addEventListener('DOMContentLoaded', function() {
 
-    const {
-        showBlockCode: showBlockCodeText = '',
-        hideBlockCode: hideBlockCodeText = '',
-        themeImportConfirm: themeImportConfirmMessage = '',
-    } = (typeof window.tejlgAdminL10n === 'object' && window.tejlgAdminL10n !== null)
+    const localization = (typeof window.tejlgAdminL10n === 'object' && window.tejlgAdminL10n !== null)
         ? window.tejlgAdminL10n
         : {};
+
+    const showBlockCodeText = typeof localization.showBlockCode === 'string'
+        ? localization.showBlockCode
+        : '';
+
+    const hideBlockCodeText = typeof localization.hideBlockCode === 'string'
+        ? localization.hideBlockCode
+        : '';
+
+    const themeImportConfirmMessage = typeof localization.themeImportConfirm === 'string'
+        ? localization.themeImportConfirm
+        : '';
 
     // Gérer la case "Tout sélectionner" pour l'import
     const selectAllCheckbox = document.getElementById('select-all-patterns');

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -32,7 +32,7 @@ class TEJLG_Admin {
                 'showBlockCode' => esc_html__('Afficher le code du bloc', 'theme-export-jlg'),
                 'hideBlockCode' => esc_html__('Masquer le code du bloc', 'theme-export-jlg'),
                 /* translators: Warning shown before importing a theme zip file. */
-                'themeImportConfirm' => __("⚠️ ATTENTION ⚠️\n\nSi un thème avec le même nom de dossier existe déjà, il sera DÉFINITIVEMENT écrasé.\n\nÊtes-vous sûr de vouloir continuer ?", 'theme-export-jlg'),
+                'themeImportConfirm' => esc_html__("⚠️ ATTENTION ⚠️\n\nSi un thème avec le même nom de dossier existe déjà, il sera DÉFINITIVEMENT écrasé.\n\nÊtes-vous sûr de vouloir continuer ?", 'theme-export-jlg'),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- escape the localized theme import confirmation message to keep the alert text safe for JavaScript consumption
- harden the admin script's localization handling by verifying the localized values are strings before use

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cdbd657230832e8a6daaa376d77685