### PR TITLE
Use wp_safe_redirect for pattern preview redirect

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -68,7 +68,7 @@ class TEJLG_Import {
         }
         set_transient($transient_id, $patterns, 15 * MINUTE_IN_SECONDS);
 
-        wp_redirect(admin_url('admin.php?page=theme-export-jlg&tab=import&action=preview_patterns&transient_id=' . $transient_id));
+        wp_safe_redirect(admin_url('admin.php?page=theme-export-jlg&tab=import&action=preview_patterns&transient_id=' . $transient_id));
         exit;
     }
 


### PR DESCRIPTION
## Summary
- replace the pattern preview redirect in `TEJLG_Import::handle_patterns_upload_step1()` with `wp_safe_redirect()` to improve URL validation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdc052603c832eb09711a6c85f76c6