### PR TITLE
Use raw slug for pattern import post names

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -150,16 +150,14 @@ class TEJLG_Import {
                     'ID'           => $existing_block->ID,
                     'post_title'   => $title,
                     'post_content' => $content,
-                    'post_name'    => $existing_block->post_name,
+                    'post_name'    => $slug,
                 ];
 
                 $result = wp_update_post(wp_slash($post_data), true);
             } else {
-                $stored_slug = 'custom-patterns/' . $slug;
-
                 $post_data = [
                     'post_title'   => $title,
-                    'post_name'    => $stored_slug,
+                    'post_name'    => $slug,
                     'post_content' => $content,
                     'post_status'  => 'publish',
                     'post_type'    => 'wp_block',


### PR DESCRIPTION
## Summary
- store imported patterns using the sanitized slug without the legacy custom-patterns/ prefix
- keep the existing slug matching logic so previously stored blocks are found and updated

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php

------
https://chatgpt.com/codex/tasks/task_e_68ce94e5f590832eb9f634087d4bee38