### PR TITLE
Handle theme install messaging states

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -24,8 +24,19 @@ class TEJLG_Import {
         $result = $upgrader->install($file['tmp_name'], ['overwrite_package' => true]);
         @unlink($file['tmp_name']);
 
-        $message_type = is_wp_error($result) || !$result ? 'error' : 'success';
-        $message_text = is_wp_error($result) ? $result->get_error_message() : esc_html__('Le thème a été installé avec succès !', 'theme-export-jlg');
+        if (is_wp_error($result)) {
+            $message_type = 'error';
+            $message_text = $result->get_error_message();
+        } elseif (false === $result) {
+            $message_type = 'error';
+            $message_text = esc_html__('L\'installation du thème a échoué.', 'theme-export-jlg');
+        } elseif (true === $result) {
+            $message_type = 'success';
+            $message_text = esc_html__('Le thème a été installé avec succès !', 'theme-export-jlg');
+        } else {
+            $message_type = 'error';
+            $message_text = esc_html__('L\'installation du thème a échoué.', 'theme-export-jlg');
+        }
 
         add_settings_error('tejlg_import_messages', 'theme_import_status', $message_text, $message_type);
     }


### PR DESCRIPTION
## Summary
- make theme import messages handle WP_Errors, explicit failure, and success results

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php

------
https://chatgpt.com/codex/tasks/task_e_68ce9bfcddc4832e868e44ac79da3525