### PR TITLE
Use sanitized slug when importing patterns

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -145,24 +145,25 @@ class TEJLG_Import {
                 }
             }
 
+            $post_data = [
+                'post_title'   => $title,
+                'post_content' => $content,
+                'post_name'    => $slug,
+            ];
+
             if ($existing_block instanceof WP_Post) {
-                $post_data = [
-                    'ID'           => $existing_block->ID,
-                    'post_title'   => $title,
-                    'post_content' => $content,
-                    'post_name'    => $slug,
-                ];
+                $post_data['ID'] = $existing_block->ID;
 
                 $result = wp_update_post(wp_slash($post_data), true);
             } else {
-                $post_data = [
-                    'post_title'   => $title,
-                    'post_name'    => $slug,
-                    'post_content' => $content,
-                    'post_status'  => 'publish',
-                    'post_type'    => 'wp_block',
-                    'post_author'  => get_current_user_id(),
-                ];
+                $post_data = array_merge(
+                    $post_data,
+                    [
+                        'post_status' => 'publish',
+                        'post_type'   => 'wp_block',
+                        'post_author' => get_current_user_id(),
+                    ]
+                );
 
                 $result = wp_insert_post(wp_slash($post_data), true);
             }


### PR DESCRIPTION
## Summary
- reuse the sanitized slug when preparing post data for imported patterns
- ensure both updates and inserts share the same slugged post data before persisting

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php

------
https://chatgpt.com/codex/tasks/task_e_68ce9be85134832e81e2c829a547f056