### PR TITLE
Refine theme import result messaging

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -24,18 +24,16 @@ class TEJLG_Import {
         $result = $upgrader->install($file['tmp_name'], ['overwrite_package' => true]);
         @unlink($file['tmp_name']);
 
+        $message_type = 'error';
+        $message_text = esc_html__('L\'installation du thème a échoué.', 'theme-export-jlg');
+
         if (is_wp_error($result)) {
-            $message_type = 'error';
             $message_text = $result->get_error_message();
         } elseif (false === $result) {
-            $message_type = 'error';
             $message_text = esc_html__('L\'installation du thème a échoué.', 'theme-export-jlg');
         } elseif (true === $result) {
             $message_type = 'success';
             $message_text = esc_html__('Le thème a été installé avec succès !', 'theme-export-jlg');
-        } else {
-            $message_type = 'error';
-            $message_text = esc_html__('L\'installation du thème a échoué.', 'theme-export-jlg');
         }
 
         add_settings_error('tejlg_import_messages', 'theme_import_status', $message_text, $message_type);


### PR DESCRIPTION
## Summary
- ensure theme import handling defaults to an error state and keeps WP_Error messages intact
- only mark the installation as successful when the upgrader result is strictly true

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cea91c43e4832ea268f2c4846ee7ae