### PR TITLE
Adjust stored pattern slug handling

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -131,13 +131,15 @@ class TEJLG_Import {
                 $content = self::sanitize_pattern_content_for_current_user((string) $pattern['content']);
             }
 
+            $candidate_slugs = array_unique([
+                $slug,
+                $original_slug,
+                '' !== $slug ? 'custom-patterns/' . $slug : '',
+            ]);
+
             $candidate_slugs = array_values(
                 array_filter(
-                    array_unique([
-                        $slug,
-                        $original_slug,
-                        'custom-patterns/' . $slug,
-                    ]),
+                    $candidate_slugs,
                     static function ($value) {
                         return '' !== $value;
                     }
@@ -154,6 +156,7 @@ class TEJLG_Import {
                 }
             }
 
+            // Always store the sanitized slug without the legacy "custom-patterns/" prefix.
             $post_data = [
                 'post_title'   => $title,
                 'post_content' => $content,


### PR DESCRIPTION
## Summary
- ensure candidate slugs cover raw, sanitized, and legacy prefixed patterns
- keep stored block slug free of the legacy custom-patterns/ prefix when saving patterns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cee6702260832ebd83aa380f62118a