### PR TITLE
Fix localized strings escaping for admin scripts

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -29,10 +29,10 @@ class TEJLG_Admin {
             'tejlg-admin-scripts',
             'tejlgAdminL10n',
             [
-                'showBlockCode' => esc_html__('Afficher le code du bloc', 'theme-export-jlg'),
-                'hideBlockCode' => esc_html__('Masquer le code du bloc', 'theme-export-jlg'),
+                'showBlockCode' => __('Afficher le code du bloc', 'theme-export-jlg'),
+                'hideBlockCode' => __('Masquer le code du bloc', 'theme-export-jlg'),
                 /* translators: Warning shown before importing a theme zip file. */
-                'themeImportConfirm' => esc_html__("⚠️ ATTENTION ⚠️\n\nSi un thème avec le même nom de dossier existe déjà, il sera DÉFINITIVEMENT écrasé.\n\nÊtes-vous sûr de vouloir continuer ?", 'theme-export-jlg'),
+                'themeImportConfirm' => __("⚠️ ATTENTION ⚠️\n\nSi un thème avec le même nom de dossier existe déjà, il sera DÉFINITIVEMENT écrasé.\n\nÊtes-vous sûr de vouloir continuer ?", 'theme-export-jlg'),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- switch localized admin strings used by JavaScript to use the raw translation helper so HTML entities are not encoded
- verify the associated JavaScript only injects the strings via `textContent` or `window.confirm`, so no additional escaping is required

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf182a86c0832eb0737f0e441ac8c0