### PR TITLE
Handle empty pattern import errors via transient

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -73,7 +73,16 @@ class TEJLG_Import {
                 'error'
             );
 
-            wp_safe_redirect(admin_url('admin.php?page=theme-export-jlg&tab=import'));
+            $errors = get_settings_errors('tejlg_import_messages');
+            set_transient('settings_errors', $errors, 30);
+
+            $redirect_url = add_query_arg(
+                'settings-updated',
+                'false',
+                admin_url('admin.php?page=theme-export-jlg&tab=import')
+            );
+
+            wp_safe_redirect($redirect_url);
             exit;
         }
         set_transient($transient_id, $patterns, 15 * MINUTE_IN_SECONDS);


### PR DESCRIPTION
## Summary
- store pattern import error messages in a short-lived transient when no valid patterns are found
- redirect back to the import tab with settings-updated=false so WordPress reloads the transient on the next request

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php

------
https://chatgpt.com/codex/tasks/task_e_68cf38ea851c832e9b1f0bfdceacfd10