### PR TITLE
Handle patterns upload read failures

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -80,6 +80,19 @@ class TEJLG_Import {
 
     public static function handle_patterns_upload_step1($file) {
         $json_content = file_get_contents($file['tmp_name']);
+
+        if (false === $json_content) {
+            @unlink($file['tmp_name']);
+            add_settings_error(
+                'tejlg_import_messages',
+                'patterns_import_status',
+                esc_html__("Erreur : Impossible de lire le fichier téléchargé.", 'theme-export-jlg'),
+                'error'
+            );
+
+            return;
+        }
+
         @unlink($file['tmp_name']);
 
         $patterns = json_decode($json_content, true);


### PR DESCRIPTION
## Summary
- prevent `handle_patterns_upload_step1` from decoding JSON when reading the uploaded file fails
- surface a user-facing error message and clean up the temporary file on read failure

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php

------
https://chatgpt.com/codex/tasks/task_e_68cfdf41a49c832ebc0b170643cd3192