### PR TITLE
Adjust child theme enqueue versions

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-theme-tools.php
+++ b/theme-export-jlg/includes/class-tejlg-theme-tools.php
@@ -73,9 +73,11 @@ class TEJLG_Theme_Tools {
  * Enqueue scripts and styles.
  */
 function %1$s_enqueue_styles() {
-    $theme_version = wp_get_theme()->get( \'Version\' );
-    wp_enqueue_style( \'%2$s-parent-style\', get_template_directory_uri() . \'/style.css\', array(), $theme_version );
-    wp_enqueue_style( \'%2$s-child-style\', get_stylesheet_uri(), array( \'%2$s-parent-style\' ), $theme_version );
+    $child_theme = wp_get_theme();
+    $parent_version = $child_theme->parent() ? $child_theme->parent()->get( \'Version\' ) : $child_theme->get( \'Version\' );
+    $child_version = $child_theme->get( \'Version\' );
+    wp_enqueue_style( \'%2$s-parent-style\', get_template_directory_uri() . \'/style.css\', array(), $parent_version );
+    wp_enqueue_style( \'%2$s-child-style\', get_stylesheet_uri(), array( \'%2$s-parent-style\' ), $child_version );
 }
 add_action( \'wp_enqueue_scripts\', \'%1$s_enqueue_styles\' );
 ',


### PR DESCRIPTION
## Summary
- set the generated child theme functions.php to calculate parent and child versions separately
- use the respective versions when enqueueing the parent and child styles

## Testing
- php -l theme-export-jlg/includes/class-tejlg-theme-tools.php

------
https://chatgpt.com/codex/tasks/task_e_68d05348592c832e91c4e88a22776f83