### PR TITLE
Handle non-boolean theme import results

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -62,17 +62,18 @@ class TEJLG_Import {
             $file_upload->cleanup();
         }
 
-        $message_type = 'error';
+        $message_type = 'info';
+        $message_text = esc_html__('Le processus d\'installation du thème a renvoyé un résultat inattendu.', 'theme-export-jlg');
 
         if (is_wp_error($result)) {
+            $message_type = 'error';
             $message_text = $result->get_error_message();
         } elseif (false === $result) {
+            $message_type = 'error';
             $message_text = esc_html__('L\'installation du thème a échoué.', 'theme-export-jlg');
-        } elseif (true === $result) {
+        } elseif (false !== $result) {
             $message_type = 'success';
             $message_text = esc_html__('Le thème a été installé avec succès !', 'theme-export-jlg');
-        } else {
-            $message_text = esc_html__('L\'installation du thème a échoué.', 'theme-export-jlg');
         }
 
         add_settings_error('tejlg_import_messages', 'theme_import_status', $message_text, $message_type);


### PR DESCRIPTION
## Summary
- treat any non-false, non-WP_Error install result as a success during theme import
- default to an informational fallback message when the install result is unexpected

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php

------
https://chatgpt.com/codex/tasks/task_e_68d25d91f48c832e836eeb39761f60e9