### PR TITLE
Optimize pattern selection query

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -241,6 +241,9 @@ class TEJLG_Admin {
             'post_status' => 'publish',
             'orderby' => 'title',
             'order' => 'ASC',
+            'no_found_rows' => true,
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
         ]);
         ?>
         <p><a href="<?php echo esc_url(add_query_arg(['page' => 'theme-export-jlg', 'tab' => 'export'], admin_url('admin.php'))); ?>">&larr; <?php esc_html_e('Retour aux outils principaux', 'theme-export-jlg'); ?></a></p>


### PR DESCRIPTION
## Summary
- disable unnecessary found rows and cache priming when listing reusable blocks for export selection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d26bc3eb10832e963cca98ebc854e2