### PR TITLE
Invalidate theme caches after child theme creation

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-theme-tools.php
+++ b/theme-export-jlg/includes/class-tejlg-theme-tools.php
@@ -162,6 +162,13 @@ PHP;
             return;
         }
 
+        wp_clean_themes_cache();
+        delete_site_transient( 'update_themes' );
+
+        if ( is_multisite() ) {
+            clean_site_details_cache();
+        }
+
         $themes_page_url = admin_url('themes.php');
         $success_message = sprintf(
             /* translators: 1: Child theme name, 2: URL to the themes admin page. */


### PR DESCRIPTION
## Summary
- clear theme-related caches after creating child theme files to ensure immediate availability
- refresh multisite details cache when applicable before showing success message

## Testing
- php -l includes/class-tejlg-theme-tools.php

------
https://chatgpt.com/codex/tasks/task_e_68d27349ae78832e8cda79304f4725d3