### PR TITLE
Add pattern search filter for export selection

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -129,6 +129,18 @@
     padding-bottom: 1rem;
 }
 
+.pattern-selection-search {
+    margin: 1rem 0;
+}
+
+#pattern-search {
+    width: 100%;
+    max-width: 100%;
+    padding: 6px 10px;
+    font-size: 14px;
+    box-sizing: border-box;
+}
+
 .pattern-selection-list ul {
     max-height: 400px;
     overflow-y: auto;
@@ -142,4 +154,8 @@
     padding: 0.25rem 0;
     list-style: none;
     margin: 0;
+}
+
+.pattern-selection-list li.is-hidden {
+    display: none;
 }

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -258,9 +258,13 @@ class TEJLG_Admin {
 
                 <div class="pattern-selection-list">
                     <p class="select-all-wrapper"><label><input type="checkbox" id="select-all-export-patterns"> <strong><?php esc_html_e('Tout sélectionner', 'theme-export-jlg'); ?></strong></label></p>
-                    <ul>
+                    <p class="pattern-selection-search">
+                        <label class="screen-reader-text" for="pattern-search"><?php esc_html_e('Rechercher une composition', 'theme-export-jlg'); ?></label>
+                        <input type="search" id="pattern-search" placeholder="<?php echo esc_attr__('Rechercher…', 'theme-export-jlg'); ?>">
+                    </p>
+                    <ul class="pattern-selection-items" aria-live="polite">
                         <?php while ($patterns_query->have_posts()): $patterns_query->the_post(); ?>
-                            <li>
+                            <li class="pattern-selection-item" data-label="<?php echo esc_attr(get_the_title()); ?>">
                                 <label>
                                     <input type="checkbox" name="selected_patterns[]" value="<?php echo esc_attr(get_the_ID()); ?>">
                                     <?php echo esc_html(get_the_title()); ?>


### PR DESCRIPTION
## Summary
- add a search field to the pattern selection page and expose metadata for filtering
- implement client-side filtering with proper “select all” handling based on visible items
- style the search control and hidden state while preserving scrollable list behaviour

## Testing
- php -l includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d2761fe4ac832e96f21fc49ebd8d0d