### PR TITLE
Ensure exports disable caching and flush buffers

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -36,10 +36,15 @@ class TEJLG_Export {
         }
         $zip->close();
 
+        nocache_headers();
+        self::clear_output_buffers();
         header('Content-Type: application/zip');
         header('Content-Disposition: attachment; filename="' . $zip_file_name . '"');
         header('Content-Length: ' . filesize($zip_file_path));
         readfile($zip_file_path);
+        if (function_exists('flush')) {
+            flush();
+        }
 
         unlink($zip_file_path);
         exit;
@@ -238,10 +243,24 @@ class TEJLG_Export {
             );
         }
 
+        nocache_headers();
+        self::clear_output_buffers();
         header('Content-Type: application/json; charset=utf-8');
         header('Content-Disposition: attachment; filename="' . $filename . '"');
         header('Content-Length: ' . strlen($json_data));
         echo $json_data;
+        if (function_exists('flush')) {
+            flush();
+        }
         exit;
+    }
+
+    /**
+     * Purge tous les tampons de sortie actifs.
+     */
+    private static function clear_output_buffers() {
+        while (ob_get_level()) {
+            ob_end_clean();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- prevent browser/proxy caching and clear buffered output before streaming archive and JSON exports
- add optional flush calls after streaming responses and centralize buffer clearing in a reusable helper

## Testing
- php -l theme-export-jlg/includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68d27624cf90832eb278281c748a9c6f