### PR TITLE
Add exclusion pattern support to theme export

### DIFF
--- a/theme-export-jlg/languages/theme-export-jlg.pot
+++ b/theme-export-jlg/languages/theme-export-jlg.pot
@@ -495,6 +495,22 @@ msgstr[1] ""
 msgid "Aucune composition n'a pu être enregistrée (elles existent peut-être déjà ou des erreurs sont survenues)."
 msgstr ""
 
+#: includes/class-tejlg-admin.php:221
+msgid "Motifs d'exclusion (optionnel) :"
+msgstr ""
+
+#: includes/class-tejlg-admin.php:222
+msgid "Ex. : assets/*.scss"
+msgstr ""
+
+#: includes/class-tejlg-admin.php:223
+msgid "Indiquez un motif par ligne ou séparez-les par des virgules (joker * accepté)."
+msgstr ""
+
+#: includes/class-tejlg-export.php:68
+msgid "Erreur : tous les fichiers ont été exclus de l'export. Vérifiez vos motifs."
+msgstr ""
+
 #: includes/class-tejlg-theme-tools.php:7
 msgid "Erreur : Le thème actif est déjà un thème enfant. Vous ne pouvez pas créer un enfant d'un enfant."
 msgstr ""


### PR DESCRIPTION
## Summary
- allow admins to specify exclusion patterns when exporting the active theme
- parse submitted patterns into an array before delegating to the export routine
- skip matching files during export, surface an error when all files are excluded, and add translations for new UI strings

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php
- php -l theme-export-jlg/includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68d27624e0c4832e95c760138fdb8057