### PR TITLE
Harden exclusion pattern handling

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -45,7 +45,7 @@ class TEJLG_Admin {
             if (isset($_POST['tejlg_export_theme'])) {
                 $exclusions = [];
 
-                if (isset($_POST['tejlg_exclusion_patterns'])) {
+                if (isset($_POST['tejlg_exclusion_patterns']) && is_string($_POST['tejlg_exclusion_patterns'])) {
                     $raw_patterns = wp_unslash($_POST['tejlg_exclusion_patterns']);
                     $split_patterns = preg_split('/[\r\n,]+/', $raw_patterns);
 
@@ -220,8 +220,8 @@ class TEJLG_Admin {
                 <?php
                 $exclusion_patterns_value = '';
 
-                if (isset($_POST['tejlg_exclusion_patterns'])) {
-                    $exclusion_patterns_value = sanitize_textarea_field(wp_unslash($_POST['tejlg_exclusion_patterns']));
+                if (isset($_POST['tejlg_exclusion_patterns']) && is_string($_POST['tejlg_exclusion_patterns'])) {
+                    $exclusion_patterns_value = wp_unslash($_POST['tejlg_exclusion_patterns']);
                 }
                 ?>
                 <form method="post" action="">

--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -12,7 +12,16 @@ class TEJLG_Export {
         $exclusions = array_values(array_filter(
             array_map(
                 static function ($pattern) {
+                    if (!is_scalar($pattern)) {
+                        return '';
+                    }
+
                     $pattern = trim((string) $pattern);
+
+                    if ('' === $pattern) {
+                        return '';
+                    }
+
                     return ltrim($pattern, "\\/");
                 },
                 (array) $exclusions


### PR DESCRIPTION
## Summary
- validate that exclusion pattern submissions are strings before parsing them during export requests
- keep the raw textarea input when redisplaying the export form so admins can edit their patterns without losing formatting
- ignore non-scalar exclusion entries while normalizing theme export filters

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php
- php -l theme-export-jlg/includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68d27f4e3998832e9bf83162253664cb