### PR TITLE
Add stacked metrics badge for FPS and latency

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -13,6 +13,45 @@
     box-shadow: 0 1px 1px rgba(0,0,0,.04);
 }
 
+.metrics-badge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border: 1px solid #ccd0d4;
+    border-radius: 6px;
+    background: #fff;
+    width: max-content;
+    margin-bottom: 20px;
+}
+
+.metrics-badge .metric {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+.metrics-badge .metric-icon {
+    font-size: 26px;
+    line-height: 1;
+}
+
+.metrics-badge .metric-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #555d66;
+}
+
+.metrics-badge .metric-value {
+    font-size: 16px;
+    font-weight: 700;
+    color: #1d2327;
+}
+
 /* Style pour l'aperçu des compositions */
 .pattern-item {
     border: 1px solid #ccd0d4;

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -356,6 +356,18 @@ class TEJLG_Admin {
             ? sprintf('<span style="color:green;">%s</span>', esc_html__('Activée', 'theme-export-jlg'))
             : sprintf('<span style="color:red; font-weight: bold;">%s</span>', esc_html__('Manquante (CRITIQUE pour la fiabilité des exports JSON)', 'theme-export-jlg'));
         ?>
+        <div class="metrics-badge" role="group" aria-label="<?php esc_attr_e('Indicateurs de performance', 'theme-export-jlg'); ?>">
+            <div class="metric metric-fps">
+                <span class="metric-icon metric-icon-fps dashicons dashicons-dashboard" aria-hidden="true"></span>
+                <span class="metric-label"><?php esc_html_e('FPS', 'theme-export-jlg'); ?></span>
+                <span class="metric-value" id="tejlg-metric-fps">--</span>
+            </div>
+            <div class="metric metric-latency">
+                <span class="metric-icon metric-icon-latency dashicons dashicons-clock" aria-hidden="true"></span>
+                <span class="metric-label"><?php esc_html_e('Latence', 'theme-export-jlg'); ?></span>
+                <span class="metric-value" id="tejlg-metric-latency">--</span>
+            </div>
+        </div>
         <h2><?php esc_html_e('Outils de Débogage', 'theme-export-jlg'); ?></h2>
         <p><?php esc_html_e('Ces informations peuvent vous aider à diagnostiquer des problèmes liés à votre configuration ou à vos données.', 'theme-export-jlg'); ?></p>
         <div id="debug-accordion">


### PR DESCRIPTION
## Summary
- wrap the FPS and latency indicators in a new `metrics-badge` container on the debug tab with descriptive classes
- add flexbox styling so the FPS and latency icons stack vertically with consistent spacing

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d32a1a58f4832e923eb37efa3686e7