### PR TITLE
Clean import uploads and normalize zip paths

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -64,7 +64,7 @@ class TEJLG_Export {
                     continue;
                 }
 
-                $zip->addFile($file_path, $relative_path);
+                $zip->addFile($file_path, $normalized_relative_path);
                 $files_added++;
             }
         }

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -39,10 +39,18 @@ class TEJLG_Import {
         );
 
         if (false === $filesystem_credentials) {
+            if ($file_upload instanceof File_Upload_Upgrader) {
+                $file_upload->cleanup();
+            }
+
             return;
         }
 
         if (!WP_Filesystem($filesystem_credentials, $theme_root)) {
+            if ($file_upload instanceof File_Upload_Upgrader) {
+                $file_upload->cleanup();
+            }
+
             request_filesystem_credentials($page_url, '', true, $theme_root, [$package_param]);
 
             return;


### PR DESCRIPTION
## Summary
- ensure uploaded theme archives are cleaned up when filesystem credential checks fail
- use normalized relative paths when adding files to the export zip to avoid platform-specific separators

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php
- php -l theme-export-jlg/includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68d3a611f82c832e84de6bd0f15d9bb1