### PR TITLE
Improve pattern portability and preserve failed imports

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -244,6 +244,15 @@ class TEJLG_Export {
                 static function ($matches) use ($home_path) {
                     $relative = wp_make_link_relative($matches[0]);
 
+                    if ('' !== $relative && preg_match('#^https?://#i', $relative)) {
+                        $parsed_url = wp_parse_url($matches[0]);
+
+                        $path      = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+                        $query     = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+                        $fragment  = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+                        $relative  = $path . $query . $fragment;
+                    }
+
                     if ('' !== $home_path && 0 === strpos($relative, $home_path)) {
                         $relative = substr($relative, strlen($home_path));
 
@@ -252,7 +261,15 @@ class TEJLG_Export {
                         }
                     }
 
-                    return '' !== $relative ? $relative : '/';
+                    if ('' === $relative) {
+                        return '/';
+                    }
+
+                    if ('/' !== $relative[0]) {
+                        $relative = '/' . ltrim($relative, '/');
+                    }
+
+                    return $relative;
                 },
                 $content
             );


### PR DESCRIPTION
## Summary
- ensure portable pattern exports convert bare site URLs to relative paths
- keep failed pattern imports available for retry by restoring the transient payload

## Testing
- php -l theme-export-jlg/includes/class-tejlg-export.php
- php -l theme-export-jlg/includes/class-tejlg-import.php

------
https://chatgpt.com/codex/tasks/task_e_68d3be505cb4832e9bb7f78e5ba148a3