### PR TITLE
Allow metric icons to be sized from settings

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -14,7 +14,7 @@
 }
 
 .metrics-badge {
-    display: flex;
+    display: inline-flex;
     flex-direction: column;
     align-items: center;
     gap: 12px;
@@ -22,8 +22,32 @@
     border: 1px solid #ccd0d4;
     border-radius: 6px;
     background: #fff;
-    width: max-content;
     margin-bottom: 20px;
+}
+
+.metrics-settings-form {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border: 1px solid #ccd0d4;
+    border-radius: 6px;
+    background: #fff;
+    margin-bottom: 20px;
+}
+
+.metrics-settings-form label {
+    font-weight: 600;
+}
+
+.metrics-settings-form input[type="number"] {
+    width: 90px;
+}
+
+.metrics-settings-form .description {
+    margin: 0;
+    width: 100%;
 }
 
 .metrics-badge .metric {
@@ -34,7 +58,7 @@
 }
 
 .metrics-badge .metric-icon {
-    font-size: 26px;
+    font-size: var(--tejlg-metric-icon-size, 26px);
     line-height: 1;
 }
 


### PR DESCRIPTION
## Summary
- allow the metrics badge and settings form to size themselves to their content and introduce reusable styling
- add an admin form on the debug tab to configure the metric icon size with validation and persistence
- wire the saved icon size into the admin stylesheet via a CSS variable so the menu aligns with the chosen size

## Testing
- php -l includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c4c4b810832e92e1b09bb3db58df