### PR TITLE
Harden exports and improve import UX

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -67,6 +67,42 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    const previewWrappers = document.querySelectorAll('.pattern-preview-wrapper');
+    if (previewWrappers.length && typeof URL === 'object' && typeof URL.createObjectURL === 'function') {
+        const blobUrls = [];
+
+        previewWrappers.forEach(function(wrapper) {
+            const dataElement = wrapper.querySelector('.pattern-preview-data');
+            const iframe = wrapper.querySelector('.pattern-preview-iframe');
+
+            if (!dataElement || !iframe) {
+                return;
+            }
+
+            let htmlContent = '';
+            try {
+                htmlContent = JSON.parse(dataElement.textContent || '""');
+            } catch (error) {
+                htmlContent = '';
+            }
+
+            if (typeof htmlContent !== 'string' || htmlContent === '') {
+                return;
+            }
+
+            const blob = new Blob([htmlContent], { type: 'text/html' });
+            const blobUrl = URL.createObjectURL(blob);
+            iframe.src = blobUrl;
+            blobUrls.push(blobUrl);
+        });
+
+        window.addEventListener('beforeunload', function() {
+            blobUrls.forEach(function(blobUrl) {
+                URL.revokeObjectURL(blobUrl);
+            });
+        });
+    }
+
     // Gérer la confirmation d'importation de thème
     const themeImportForm = document.getElementById('tejlg-import-theme-form');
     if (themeImportForm && themeImportConfirmMessage) {


### PR DESCRIPTION
## Summary
- block symlinks and out-of-tree paths when adding theme files to the export zip
- redirect back to the Import tab after completing step 2 so feedback appears in the right place
- replace srcdoc previews with blob-backed iframes to avoid browser attribute size limits

## Testing
- php -l includes/class-tejlg-export.php
- php -l includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c52232d4832ebdfc5d02c41fd189