### PR TITLE
Adjust metrics menu defaults

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -21,7 +21,7 @@
     padding: 12px 16px;
     border: 1px solid #ccd0d4;
     border-radius: 6px;
-    background: #fff;
+    background: rgba(255, 255, 255, 0.9);
     margin-bottom: 20px;
 }
 
@@ -58,7 +58,7 @@
 }
 
 .metrics-badge .metric-icon {
-    font-size: var(--tejlg-metric-icon-size, 26px);
+    font-size: var(--tejlg-metric-icon-size, 60px);
     line-height: 1;
 }
 

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -2,7 +2,7 @@
 class TEJLG_Admin {
 
     const METRICS_ICON_OPTION  = 'tejlg_metrics_icon_size';
-    const METRICS_ICON_DEFAULT = 26;
+    const METRICS_ICON_DEFAULT = 60;
     const METRICS_ICON_MIN     = 12;
     const METRICS_ICON_MAX     = 128;
 


### PR DESCRIPTION
## Summary
- raise the default metrics menu icon size to 60px and ensure the inline fallback matches
- soften the metrics badge background with a 10% transparency to match the new default appearance

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d3e04ab4c8832e8378825556f22850