### PR TITLE
Validate admin redirects with safe fallbacks

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -101,6 +101,9 @@ class TEJLG_Admin {
                 admin_url('admin.php')
             );
 
+            $fallback_url = admin_url('admin.php?page=theme-export-jlg&tab=debug');
+            $redirect_url = wp_validate_redirect($redirect_url, $fallback_url);
+
             wp_safe_redirect($redirect_url);
             exit;
         }
@@ -232,6 +235,9 @@ class TEJLG_Admin {
 
                 $redirect_url = add_query_arg($redirect_args, admin_url('admin.php'));
 
+                $fallback_url = admin_url('admin.php?page=theme-export-jlg&tab=import');
+                $redirect_url = wp_validate_redirect($redirect_url, $fallback_url);
+
                 wp_safe_redirect($redirect_url);
                 exit;
             }
@@ -256,6 +262,9 @@ class TEJLG_Admin {
                 ],
                 admin_url('admin.php')
             );
+
+            $fallback_url = admin_url('admin.php?page=theme-export-jlg&tab=import');
+            $redirect_url = wp_validate_redirect($redirect_url, $fallback_url);
 
             wp_safe_redirect($redirect_url);
             exit;

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -202,14 +202,28 @@ class TEJLG_Import {
                 admin_url('admin.php?page=theme-export-jlg&tab=import')
             );
 
+            $fallback_url = admin_url('admin.php?page=theme-export-jlg&tab=import');
+            $redirect_url = wp_validate_redirect($redirect_url, $fallback_url);
+
             wp_safe_redirect($redirect_url);
             exit;
         }
         set_transient($transient_id, $patterns, 15 * MINUTE_IN_SECONDS);
 
-        wp_safe_redirect(
-            admin_url('admin.php?page=theme-export-jlg&tab=import&action=preview_patterns&transient_id=' . $transient_id)
+        $redirect_url = add_query_arg(
+            [
+                'page'         => 'theme-export-jlg',
+                'tab'          => 'import',
+                'action'       => 'preview_patterns',
+                'transient_id' => $transient_id,
+            ],
+            admin_url('admin.php')
         );
+
+        $fallback_url = admin_url('admin.php?page=theme-export-jlg&tab=import');
+        $redirect_url = wp_validate_redirect($redirect_url, $fallback_url);
+
+        wp_safe_redirect($redirect_url);
         exit;
     }
 


### PR DESCRIPTION
## Summary
- validate all admin redirect targets before calling `wp_safe_redirect`
- ensure pattern import redirects reuse add_query_arg and include fallback URLs

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d3e6896954832e8fb796b919de3507