### PR TITLE
Fix pattern preview and stream JSON exports

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -710,9 +710,20 @@ class TEJLG_Admin {
             return;
         }
 
-        $patterns = get_transient($transient_id);
-        if (false === $patterns) {
+        $storage = get_transient($transient_id);
+        if (false === $storage) {
             echo '<div class="error"><p>' . esc_html__('La session d\'importation a expiré ou est invalide. Veuillez téléverser à nouveau votre fichier.', 'theme-export-jlg') . '</p></div>';
+            return;
+        }
+
+        $patterns = TEJLG_Import::retrieve_patterns_from_storage($storage);
+
+        if (is_wp_error($patterns)) {
+            TEJLG_Import::delete_patterns_storage($transient_id, $storage);
+
+            echo '<div class="error"><p>' . esc_html($patterns->get_error_message()) . '</p></div>';
+            echo '<p><a href="' . esc_url(add_query_arg(['page' => 'theme-export-jlg', 'tab' => 'import'], admin_url('admin.php'))) . '">&larr; ' . esc_html__('Retour au formulaire d\'import', 'theme-export-jlg') . '</a></p>';
+
             return;
         }
 
@@ -802,7 +813,7 @@ class TEJLG_Admin {
         }
 
         if (empty($prepared_patterns) || !$has_renderable_pattern) {
-            delete_transient($transient_id);
+            TEJLG_Import::delete_patterns_storage($transient_id, $storage);
             echo '<div class="error"><p>' . esc_html__('Erreur : Aucune composition valide n\'a pu être prévisualisée. Veuillez vérifier le fichier importé.', 'theme-export-jlg') . '</p></div>';
             echo '<p><a href="' . esc_url(add_query_arg(['page' => 'theme-export-jlg', 'tab' => 'import'], admin_url('admin.php'))) . '">&larr; ' . esc_html__('Retour au formulaire d\'import', 'theme-export-jlg') . '</a></p>';
             return;

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -608,7 +608,7 @@ class TEJLG_Import {
         ];
     }
 
-    private static function retrieve_patterns_from_storage($storage) {
+    public static function retrieve_patterns_from_storage($storage) {
         if (is_array($storage) && isset($storage['type']) && 'file' === $storage['type']) {
             $path = isset($storage['path']) ? (string) $storage['path'] : '';
 
@@ -660,7 +660,7 @@ class TEJLG_Import {
         }
     }
 
-    private static function delete_patterns_storage($transient_id, $storage) {
+    public static function delete_patterns_storage($transient_id, $storage) {
         self::cleanup_patterns_storage($storage);
         delete_transient($transient_id);
     }


### PR DESCRIPTION
## Summary
- fix the pattern preview step by reading the persisted payload and cleaning up the session when it fails
- expose storage helpers so the admin UI can surface storage errors to the user
- stream block-pattern exports in batches to a temporary file before download to reduce memory usage

## Testing
- php -l theme-export-jlg/includes/class-tejlg-import.php
- php -l theme-export-jlg/includes/class-tejlg-admin.php
- php -l theme-export-jlg/includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68d43623dc88832e81bfe66c9ded9790