### PR TITLE
Secure pattern import storage and cleanup

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -52,6 +52,8 @@ class TEJLG_Admin {
             return;
         }
 
+        TEJLG_Import::cleanup_expired_patterns_storage();
+
         $this->handle_metrics_settings_request();
         $this->handle_export_requests();
         $this->handle_selected_patterns_export_request();


### PR DESCRIPTION
## Summary
- trigger a cleanup of stale pattern import files on admin init and before persisting new sessions
- encapsulate the patterns storage expiration and purge stale temp files based on configurable thresholds
- validate stored pattern payloads with size, checksum, and count checks before allowing imports

## Testing
- find theme-export-jlg -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d4408b7de4832ea3bc443db59a1eb3