### PR TITLE
Improve temporary file cleanup and child theme permissions

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-theme-tools.php
+++ b/theme-export-jlg/includes/class-tejlg-theme-tools.php
@@ -2,6 +2,20 @@
 class TEJLG_Theme_Tools {
 
     public static function create_child_theme( $child_name ) {
+        if ( ! current_user_can( 'install_themes' ) ) {
+            add_settings_error(
+                'tejlg_admin_messages',
+                'child_theme_capabilities',
+                esc_html__(
+                    "Erreur : Vous n'avez pas les autorisations nécessaires pour créer ou installer des thèmes.",
+                    'theme-export-jlg'
+                ),
+                'error'
+            );
+
+            return;
+        }
+
         if (
             ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) ||
             ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT )


### PR DESCRIPTION
## Summary
- run the patterns storage cleanup only when loading the plugin screen instead of every admin request
- add a helper to silently delete ZIP temp files and surface a translated error if the file cannot be prepared
- require the `install_themes` capability before processing child theme creation requests and surface a clear error when missing

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php
- php -l theme-export-jlg/includes/class-tejlg-export.php
- php -l theme-export-jlg/includes/class-tejlg-theme-tools.php

------
https://chatgpt.com/codex/tasks/task_e_68d44c29e2cc832e96ea407ae652b076