### PR TITLE
Improve admin feedback and harden export/import workflows

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -111,7 +111,13 @@ class TEJLG_Admin {
 
         update_option(self::METRICS_ICON_OPTION, $icon_size);
 
+        $has_error = false;
+
         foreach ($messages as $message) {
+            if (isset($message['type']) && 'error' === $message['type']) {
+                $has_error = true;
+            }
+
             add_settings_error('tejlg_debug_messages', $message['code'], $message['message'], $message['type']);
         }
 
@@ -122,7 +128,7 @@ class TEJLG_Admin {
             [
                 'page'             => 'theme-export-jlg',
                 'tab'              => 'debug',
-                'settings-updated' => 'true',
+                'settings-updated' => $has_error ? 'false' : 'true',
             ],
             admin_url('admin.php')
         );


### PR DESCRIPTION
## Summary
- avoid forcing the WordPress success notice when the debug settings submission falls back to the default value
- stop the theme export when ZipArchive refuses to add a file or directory and report a clear error after cleaning up
- accept additional pattern metadata keys when deriving imported slugs and broaden duplicate detection

## Testing
- find theme-export-jlg -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d50ab18eac832e9cb22f46d0431dfa