### PR TITLE
Fix pattern sanitizer regex and add regression test

### DIFF
--- a/tests/test-pattern-sanitizer.php
+++ b/tests/test-pattern-sanitizer.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-import.php';
+
+/**
+ * @group pattern-sanitizer
+ */
+class Test_Pattern_Sanitizer extends WP_UnitTestCase {
+
+    public function test_block_comments_preserved_with_greater_than_in_attributes() {
+        $user_id = self::factory()->user->create([
+            'role' => 'subscriber',
+        ]);
+
+        wp_set_current_user($user_id);
+
+        $raw_content = '<!-- wp:paragraph {"placeholder": ">"} -->Hello<!-- /wp:paragraph -->';
+
+        $method = new ReflectionMethod(TEJLG_Import::class, 'sanitize_pattern_content_for_current_user');
+        $method->setAccessible(true);
+
+        $sanitized_content = $method->invoke(null, $raw_content);
+
+        $this->assertStringContainsString('<!-- wp:paragraph {"placeholder": ">"} -->', $sanitized_content);
+        $this->assertStringContainsString('<!-- /wp:paragraph -->', $sanitized_content);
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -1207,7 +1207,7 @@ class TEJLG_Import {
         $block_comment_tokens = [];
 
         $tokenized_content = preg_replace_callback(
-            '/<!--\s*(\/?.*?wp:[^>]*?)\s*-->/',
+            '/<!--\s*\/?wp:(?:[\s\S]*?)-->/',
             function ($matches) use (&$block_comment_tokens) {
                 $token = TEJLG_Import::generate_block_comment_token($block_comment_tokens);
                 $block_comment_tokens[$token] = $matches[0];


### PR DESCRIPTION
## Summary
- update the pattern sanitizer to capture full block comments even when attributes contain greater-than characters
- add a regression test to verify users without the unfiltered_html capability keep opening and closing block comments

## Testing
- phpunit --testsuite plugin *(fails: phpunit command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d65fb7d754832eaf21fb1cd7cf5d2d