### PR TITLE
Handle quoted block comment delimiters in pattern sanitizer

### DIFF
--- a/tests/test-pattern-sanitizer.php
+++ b/tests/test-pattern-sanitizer.php
@@ -24,4 +24,22 @@ class Test_Pattern_Sanitizer extends WP_UnitTestCase {
         $this->assertStringContainsString('<!-- wp:paragraph {"placeholder": ">"} -->', $sanitized_content);
         $this->assertStringContainsString('<!-- /wp:paragraph -->', $sanitized_content);
     }
+
+    public function test_block_comments_preserved_with_closing_sequence_in_attributes() {
+        $user_id = self::factory()->user->create([
+            'role' => 'subscriber',
+        ]);
+
+        wp_set_current_user($user_id);
+
+        $raw_content = '<!-- wp:paragraph {"placeholder": "-->"} -->Content<!-- /wp:paragraph -->';
+
+        $method = new ReflectionMethod(TEJLG_Import::class, 'sanitize_pattern_content_for_current_user');
+        $method->setAccessible(true);
+
+        $sanitized_content = $method->invoke(null, $raw_content);
+
+        $this->assertStringContainsString('<!-- wp:paragraph {"placeholder": "-->"} -->', $sanitized_content);
+        $this->assertStringContainsString('<!-- /wp:paragraph -->', $sanitized_content);
+    }
 }


### PR DESCRIPTION
## Summary
- tokenize block comments by scanning markup so escaped or quoted `-->` sequences inside block attributes do not prematurely terminate the token
- add a regression test ensuring block comments remain intact when pattern attributes include the `-->` sequence

## Testing
- phpunit *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d66fcac1b8832e8fbf9f092c982a89