### PR TITLE
Fix pattern content cleaning for subdirectory sites

### DIFF
--- a/tests/test-pattern-sanitizer.php
+++ b/tests/test-pattern-sanitizer.php
@@ -1,11 +1,29 @@
 <?php
 
 require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-import.php';
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
 
 /**
  * @group pattern-sanitizer
  */
 class Test_Pattern_Sanitizer extends WP_UnitTestCase {
+
+    protected $previous_home_url;
+    protected $previous_site_url;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->previous_home_url = get_option('home');
+        $this->previous_site_url = get_option('siteurl');
+    }
+
+    public function tearDown(): void {
+        update_option('home', $this->previous_home_url);
+        update_option('siteurl', $this->previous_site_url);
+
+        parent::tearDown();
+    }
 
     public function test_block_comments_preserved_with_greater_than_in_attributes() {
         $user_id = self::factory()->user->create([
@@ -41,5 +59,21 @@ class Test_Pattern_Sanitizer extends WP_UnitTestCase {
 
         $this->assertStringContainsString('<!-- wp:paragraph {"placeholder": "-->"} -->', $sanitized_content);
         $this->assertStringContainsString('<!-- /wp:paragraph -->', $sanitized_content);
+    }
+
+    public function test_clean_pattern_content_preserves_prefixed_paths_outside_home_path() {
+        update_option('home', 'http://example.com/sub');
+        update_option('siteurl', 'http://example.com/sub');
+
+        $content = '<a href="http://example.com/sub/page">Page</a>'
+            . '<a href="http://example.com/submarine-news">News</a>';
+
+        $method = new ReflectionMethod(TEJLG_Export::class, 'clean_pattern_content');
+        $method->setAccessible(true);
+
+        $cleaned = $method->invoke(null, $content);
+
+        $this->assertStringContainsString('href="/page"', $cleaned);
+        $this->assertStringContainsString('href="/submarine-news"', $cleaned);
     }
 }

--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -626,10 +626,14 @@ class TEJLG_Export {
                     }
 
                     if ('' !== $home_path && 0 === strpos($relative, $home_path)) {
-                        $relative = substr($relative, strlen($home_path));
+                        $remaining = substr($relative, strlen($home_path));
 
-                        if ($relative === '' || '/' !== $relative[0]) {
-                            $relative = '/' . ltrim($relative, '/');
+                        if ($remaining === '' || in_array($remaining[0], ['/', '?', '#'], true)) {
+                            $relative = $remaining;
+
+                            if ($relative === '' || '/' !== $relative[0]) {
+                                $relative = '/' . ltrim($relative, '/');
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary
- prevent `clean_pattern_content()` from stripping matching prefixes unless the next character is `/`, `?`, or `#`
- add a regression test covering subdirectory home URLs and ensure options are restored after the test

## Testing
- npm test *(fails: phpunit missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69861690c832ea19ff5b43d1a4ab8