### PR TITLE
Preserve subdirectory prefixes in pattern export

### DIFF
--- a/tests/test-pattern-sanitizer.php
+++ b/tests/test-pattern-sanitizer.php
@@ -76,4 +76,39 @@ class Test_Pattern_Sanitizer extends WP_UnitTestCase {
         $this->assertStringContainsString('href="/page"', $cleaned);
         $this->assertStringContainsString('href="/submarine-news"', $cleaned);
     }
+
+    public function test_export_patterns_json_keeps_subdirectory_prefix_for_media_urls() {
+        update_option('home', 'https://example.com/subdir');
+        update_option('siteurl', 'https://example.com/subdir');
+
+        $media_url = 'https://example.com/subdir/wp-content/uploads/2024/05/test.png';
+        $content   = '<!-- wp:image -->'
+            . '<figure class="wp-block-image"><img src="' . $media_url . '" alt=""/></figure>'
+            . '<!-- /wp:image -->';
+
+        $pattern_id = self::factory()->post->create([
+            'post_type'    => 'wp_block',
+            'post_status'  => 'publish',
+            'post_title'   => 'Subdir Pattern',
+            'post_content' => $content,
+        ]);
+
+        add_filter('tejlg_export_stream_json_file', '__return_false');
+
+        try {
+            $json = TEJLG_Export::export_selected_patterns_json([$pattern_id], true);
+        } finally {
+            remove_filter('tejlg_export_stream_json_file', '__return_false');
+        }
+
+        $this->assertIsString($json);
+        $this->assertNotSame('', $json);
+
+        $decoded = json_decode($json, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertArrayHasKey('content', $decoded[0]);
+        $this->assertStringContainsString('/subdir/wp-content/uploads/2024/05/test.png', $decoded[0]['content']);
+    }
 }


### PR DESCRIPTION
## Summary
- keep the site subdirectory prefix in portable pattern URLs returned by `clean_pattern_content`
- allow tests to capture JSON exports without streaming by adding a filter gate
- add a regression test exercising the public export path to ensure `/subdir/` survives sanitation

## Testing
- npm test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ac4c1da8832eac7e97f41ef3e7a8