### PR TITLE
Handle missing ZIP filesize before streaming

### DIFF
--- a/tests/test-export-theme.php
+++ b/tests/test-export-theme.php
@@ -1,0 +1,45 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+
+/**
+ * @group export-theme
+ */
+class Test_Export_Theme extends WP_UnitTestCase {
+
+    public function test_export_theme_dies_when_filesize_is_unavailable() {
+        $captured_temp_path = null;
+        $die_message        = null;
+
+        $filesize_filter = static function ($size, $path) use (&$captured_temp_path) {
+            $captured_temp_path = $path;
+            return false;
+        };
+
+        $wp_die_handler = static function () use (&$die_message) {
+            return static function ($message) use (&$die_message) {
+                $die_message = $message;
+                throw new WPDieException($message);
+            };
+        };
+
+        add_filter('tejlg_export_zip_file_size', $filesize_filter, 10, 2);
+        add_filter('wp_die_handler', $wp_die_handler);
+
+        try {
+            TEJLG_Export::export_theme();
+            $this->fail('Expected WPDieException was not thrown.');
+        } catch (WPDieException $exception) {
+            $this->assertNotEmpty($die_message, 'The wp_die handler should capture a message.');
+            $this->assertStringContainsString(
+                "Impossible de déterminer la taille de l'archive ZIP à télécharger.",
+                wp_strip_all_tags((string) $die_message)
+            );
+            $this->assertNotEmpty($captured_temp_path, 'The temporary ZIP path should be captured.');
+            $this->assertFileDoesNotExist($captured_temp_path, 'The temporary ZIP file should be cleaned up.');
+        } finally {
+            remove_filter('tejlg_export_zip_file_size', $filesize_filter, 10);
+            remove_filter('wp_die_handler', $wp_die_handler, 10);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate the generated ZIP file size before sending the download headers and surface a translated wp_die error when it cannot be determined
- add a WP_DEBUG log entry and a filter hook to help troubleshoot file size detection problems
- cover the failure path with a PHPUnit test that simulates a missing file size and asserts cleanup

## Testing
- `npm run test:php` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d723c541c4832eae7d481400136b00