### PR TITLE
Clean up metrics icon size option during uninstall

### DIFF
--- a/theme-export-jlg/uninstall.php
+++ b/theme-export-jlg/uninstall.php
@@ -34,3 +34,7 @@ $wpdb->query(
         $timeout_pattern
     )
 );
+
+// Supprimer l'option stockant la taille des icônes de métriques.
+delete_option( 'tejlg_metrics_icon_size' );
+delete_site_option( 'tejlg_metrics_icon_size' );


### PR DESCRIPTION
## Summary
- remove the tejlg_metrics_icon_size option during uninstall of the plugin
- ensure the option is deleted in both single-site and multisite contexts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7ce5c63c4832eab88a7b0ee6400ed