### PR TITLE
Ensure pattern preview JSON payloads are safely encoded

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -903,12 +903,16 @@ class TEJLG_Admin {
                 <?php foreach ($prepared_patterns as $pattern_data): ?>
                     <?php
                     $iframe_content = '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0"><style>' . $global_styles . '</style></head><body class="block-editor-writing-flow">' . $pattern_data['rendered'] . '</body></html>';
-                    $iframe_json = wp_json_encode(
-                        $iframe_content,
-                        JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
-                    );
+                    $json_options = JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT;
+
+                    $iframe_json = wp_json_encode($iframe_content, $json_options);
+
                     if (false === $iframe_json) {
-                        $iframe_json = '""';
+                        $iframe_json = wp_json_encode('', $json_options);
+
+                        if (false === $iframe_json) {
+                            $iframe_json = '""';
+                        }
                     }
                     ?>
                     <div class="pattern-item">


### PR DESCRIPTION
## Summary
- ensure pattern preview iframe payloads are encoded with JSON_HEX options for script safety
- retain the fallback logic by retrying with an empty string before defaulting to an empty JSON string

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d7d00ae8b8832ebeccd5f562873060