### PR TITLE
Ensure uninstall cleans up metrics option

### DIFF
--- a/theme-export-jlg/uninstall.php
+++ b/theme-export-jlg/uninstall.php
@@ -35,6 +35,6 @@ $wpdb->query(
     )
 );
 
-// Supprimer l'option stockant la taille des icônes de métriques.
+// Supprimer l'option stockant la taille des icônes de métriques (mono et multisites).
 delete_option( 'tejlg_metrics_icon_size' );
 delete_site_option( 'tejlg_metrics_icon_size' );


### PR DESCRIPTION
## Summary
- document that the uninstall routine removes the metrics icon size option for both single- and multisite installs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7d00b90a8832e93391a5a333ef078