### PR TITLE
Handle untitled patterns in export selection

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -565,8 +565,22 @@ class TEJLG_Admin {
                         <input type="search" id="pattern-search" placeholder="<?php echo esc_attr__('Rechercher…', 'theme-export-jlg'); ?>" aria-controls="pattern-selection-items">
                     </p>
                     <ul class="pattern-selection-items" id="pattern-selection-items" aria-live="polite" data-searchable="true">
-                        <?php while ($patterns_query->have_posts()): $patterns_query->the_post();
-                            $pattern_title = get_the_title();
+                        <?php
+                        $pattern_counter = $per_page > 0 ? (($current_page - 1) * $per_page) : 0;
+                        while ($patterns_query->have_posts()):
+                            $patterns_query->the_post();
+                            $pattern_counter++;
+                            $raw_title = get_the_title();
+                            if (!is_scalar($raw_title)) {
+                                $raw_title = '';
+                            }
+                            $pattern_title = trim((string) $raw_title);
+                            if ('' === $pattern_title) {
+                                $pattern_title = sprintf(
+                                    esc_html__('Composition sans titre #%d', 'theme-export-jlg'),
+                                    (int) $pattern_counter
+                                );
+                            }
                         ?>
                             <li class="pattern-selection-item" data-label="<?php echo esc_attr($pattern_title); ?>">
                                 <label>


### PR DESCRIPTION
## Summary
- add a localized fallback title when rendering untitled patterns in the export selection list
- reuse the fallback value for each item’s data-label attribute so search continues to work
- cover the untitled pattern scenario with a new Playwright test

## Testing
- npm run test:e2e *(fails: Cannot find module '@wordpress/e2e-test-utils-playwright/config')*


------
https://chatgpt.com/codex/tasks/task_e_68d80746ceec832e866fb95a86a93c25