### PR TITLE
Preserve child theme field value after validation failures

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('@wordpress/e2e-test-utils-playwright/config');
+const baseConfig = require('@wordpress/e2e-test-utils-playwright/build/config');
 
 module.exports = {
   ...baseConfig,

--- a/tests/e2e/child-theme-form.spec.js
+++ b/tests/e2e/child-theme-form.spec.js
@@ -1,0 +1,23 @@
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+
+test.describe('Child theme creation form', () => {
+  test('preserves input value after validation error', async ({ admin, page, requestUtils }) => {
+    await requestUtils.activatePlugin('theme-export-jlg/theme-export-jlg.php');
+
+    await admin.visitAdminPage('admin.php', 'page=theme-export-jlg&tab=export');
+
+    const invalidName = '!!!';
+    const childThemeInput = page.locator('#child_theme_name');
+
+    await childThemeInput.fill(invalidName);
+
+    await Promise.all([
+      page.waitForNavigation(),
+      page.click('button[name="tejlg_create_child"]'),
+    ]);
+
+    const errorNotice = page.locator('.notice.notice-error');
+    await expect(errorNotice).toContainText("Erreur : Le nom du thème enfant doit contenir des lettres ou des chiffres.");
+    await expect(childThemeInput).toHaveValue(invalidName);
+  });
+});

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -459,6 +459,18 @@ class TEJLG_Admin {
         ?>
         <?php settings_errors('tejlg_admin_messages'); ?>
 
+        <?php
+        $child_theme_value = '';
+
+        if (isset($_POST['child_theme_name'])) {
+            $raw_child_theme = $_POST['child_theme_name'];
+
+            if (is_scalar($raw_child_theme)) {
+                $child_theme_value = sanitize_text_field(wp_unslash($raw_child_theme));
+            }
+        }
+        ?>
+
         <h2><?php esc_html_e('Actions sur le Thème Actif', 'theme-export-jlg'); ?></h2>
         <div class="tejlg-cards-container">
             <div class="tejlg-card">
@@ -508,7 +520,7 @@ class TEJLG_Admin {
                     <?php wp_nonce_field('tejlg_create_child_action', 'tejlg_create_child_nonce'); ?>
                     <p>
                         <label for="child_theme_name"><?php esc_html_e('Nom du thème enfant :', 'theme-export-jlg'); ?></label>
-                        <input type="text" name="child_theme_name" id="child_theme_name" class="regular-text" placeholder="<?php echo esc_attr(wp_get_theme()->get('Name') . ' ' . __('Enfant', 'theme-export-jlg')); ?>" required>
+                        <input type="text" name="child_theme_name" id="child_theme_name" class="regular-text" value="<?php echo esc_attr($child_theme_value); ?>" placeholder="<?php echo esc_attr(wp_get_theme()->get('Name') . ' ' . __('Enfant', 'theme-export-jlg')); ?>" required>
                     </p>
                     <p><button type="submit" name="tejlg_create_child" class="button button-primary"><?php esc_html_e('Créer le Thème Enfant', 'theme-export-jlg'); ?></button></p>
                 </form>


### PR DESCRIPTION
## Summary
- persist the child theme name entered in the export tools form by sanitizing posted data and repopulating the input
- point Playwright to the packaged WordPress test utils configuration
- cover the behaviour with a Playwright test that ensures the field retains its value after a validation error

## Testing
- `npm run test:e2e -- child-theme-form.spec.js` *(fails: WordPress test environment REST API is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d83b3fa578832eb28d162b0ec690c6