### PR TITLE
Validate temporary pattern storage paths

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -1008,7 +1008,42 @@ class TEJLG_Import {
         if (is_array($storage) && isset($storage['type']) && 'file' === $storage['type']) {
             $path = isset($storage['path']) ? (string) $storage['path'] : '';
 
-            if ('' === $path || !is_readable($path)) {
+            if ('' === $path) {
+                return new WP_Error(
+                    'tejlg_import_storage_missing',
+                    __('Erreur : Le fichier temporaire de la session d\'importation est introuvable.', 'theme-export-jlg')
+                );
+            }
+
+            $temp_dir = '';
+
+            if (function_exists('get_temp_dir')) {
+                $temp_dir = get_temp_dir();
+            }
+
+            $normalized_path     = wp_normalize_path($path);
+            $normalized_temp_dir = '';
+
+            if (is_string($temp_dir) && '' !== $temp_dir) {
+                $normalized_temp_dir = wp_normalize_path(trailingslashit($temp_dir));
+            }
+
+            $path_basename = function_exists('wp_basename') ? wp_basename($normalized_path) : basename($normalized_path);
+
+            if (
+                '' === $normalized_temp_dir
+                || 0 !== strpos($normalized_path, $normalized_temp_dir)
+                || 0 !== strpos($path_basename, 'tejlg-patterns')
+            ) {
+                self::cleanup_patterns_storage($storage);
+
+                return new WP_Error(
+                    'tejlg_import_storage_invalid_path',
+                    __('Erreur : Les données temporaires de la session d\'importation ne sont pas valides.', 'theme-export-jlg')
+                );
+            }
+
+            if (!is_readable($path)) {
                 return new WP_Error(
                     'tejlg_import_storage_missing',
                     __('Erreur : Le fichier temporaire de la session d\'importation est introuvable.', 'theme-export-jlg')


### PR DESCRIPTION
## Summary
- ensure pattern storage files reside inside the WordPress temporary directory with the expected prefix before reading them
- return a dedicated error and clean up the storage when the temporary path validation fails
- add a unit test covering rejection of pattern storage files saved outside the temporary directory

## Testing
- npm run test:php -- --filter Test_Pattern_Sanitizer::test_retrieve_patterns_from_storage_rejects_path_outside_temp_dir *(fails: phpunit not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d91de96c04832e924380e4de707867