### PR TITLE
Optimize pattern export pagination and extend tests

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -300,6 +300,8 @@ class TEJLG_Export {
                 break;
             }
 
+            $current_batch_count = count($patterns_query->posts);
+
             while ($patterns_query->have_posts()) {
                 $patterns_query->the_post();
 
@@ -351,7 +353,7 @@ class TEJLG_Export {
 
             wp_reset_postdata();
 
-            if (count($patterns_query->posts) < $batch_size) {
+            if ($current_batch_count < $batch_size) {
                 break;
             }
 


### PR DESCRIPTION
## Summary
- capture the number of posts returned per page and stop pagination when the batch is smaller than the configured size
- make the batch-size test helper configurable and add coverage for exporting a partial final batch of patterns

## Testing
- npm run test:php *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d920ebf640832e87647f335fd06679