### PR TITLE
Respect DISALLOW_FILE_MODS during theme import

### DIFF
--- a/tests/test-import-theme.php
+++ b/tests/test-import-theme.php
@@ -1,0 +1,51 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-import.php';
+
+/**
+ * @group import-theme
+ */
+class Test_Import_Theme extends WP_UnitTestCase {
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_import_theme_aborts_when_file_mods_disallowed() {
+        define('DISALLOW_FILE_MODS', true);
+
+        $admin_id = self::factory()->user->create([
+            'role' => 'administrator',
+        ]);
+
+        wp_set_current_user($admin_id);
+
+        $temp_file = tempnam(sys_get_temp_dir(), 'tejlg_import_');
+        file_put_contents($temp_file, 'dummy');
+
+        $this->assertFileExists($temp_file);
+
+        $file_upload_upgrader_loaded_before = class_exists('File_Upload_Upgrader', false);
+
+        TEJLG_Import::import_theme([
+            'tmp_name' => $temp_file,
+            'name'     => 'dummy-theme.zip',
+        ]);
+
+        $this->assertFileDoesNotExist($temp_file);
+
+        $messages = get_settings_errors('tejlg_import_messages');
+
+        $this->assertNotEmpty($messages);
+        $this->assertSame('theme_import_file_mods_disabled', $messages[0]['code']);
+        $this->assertSame('error', $messages[0]['type']);
+        $this->assertStringContainsString(
+            "Erreur : Les modifications de fichiers sont désactivées sur ce site.",
+            $messages[0]['message']
+        );
+
+        if (! $file_upload_upgrader_loaded_before) {
+            $this->assertFalse(class_exists('File_Upload_Upgrader', false));
+        }
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -17,6 +17,24 @@ class TEJLG_Import {
             return;
         }
 
+        if (
+            (defined('DISALLOW_FILE_MODS') && DISALLOW_FILE_MODS) ||
+            (defined('DISALLOW_FILE_EDIT') && DISALLOW_FILE_EDIT)
+        ) {
+            if (isset($file['tmp_name'])) {
+                @unlink($file['tmp_name']);
+            }
+
+            add_settings_error(
+                'tejlg_import_messages',
+                'theme_import_file_mods_disabled',
+                esc_html__('Erreur : Les modifications de fichiers sont désactivées sur ce site.', 'theme-export-jlg'),
+                'error'
+            );
+
+            return;
+        }
+
         require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
         require_once ABSPATH . 'wp-admin/includes/file.php';
 


### PR DESCRIPTION
## Summary
- abort theme import when file modifications are disabled and surface a translated settings error
- add PHPUnit coverage to confirm the import stops early, removes the temp file, and reports the settings error

## Testing
- npm run test:php *(fails: phpunit not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d99f690204832e818ec4d4ebd51077