### PR TITLE
Add helper for safe file deletion logging

### DIFF
--- a/tests/test-files-helper.php
+++ b/tests/test-files-helper.php
@@ -1,0 +1,55 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-files.php';
+
+/**
+ * @group files
+ */
+class Test_TEJLG_Files extends WP_UnitTestCase {
+
+    public function test_delete_logs_failure_when_unlink_fails() {
+        $log_file = tempnam(sys_get_temp_dir(), 'tejlg-log-');
+        $previous_error_log = ini_set('error_log', $log_file);
+
+        $captured_doing_it_wrong_message = '';
+        $listener = static function ($function, $message, $version) use (&$captured_doing_it_wrong_message) {
+            if ('TEJLG_Files::delete' === $function) {
+                $captured_doing_it_wrong_message = $message;
+            }
+        };
+
+        add_action('doing_it_wrong_run', $listener, 10, 3);
+        $this->setExpectedIncorrectUsage('TEJLG_Files::delete');
+
+        $temp_dir = trailingslashit(sys_get_temp_dir()) . 'tejlg-delete-test-' . wp_generate_uuid4();
+        wp_mkdir_p($temp_dir);
+
+        try {
+            $result = TEJLG_Files::delete($temp_dir);
+
+            $this->assertFalse($result, 'Deleting a directory with the file helper should fail.');
+
+            $this->assertFileExists($log_file, 'The error log file should exist.');
+            $log_contents = file_get_contents($log_file);
+
+            $this->assertNotFalse($log_contents, 'The log file contents should be readable.');
+            $this->assertStringContainsString($temp_dir, (string) $log_contents, 'The log should mention the failing path.');
+            $this->assertNotEmpty($captured_doing_it_wrong_message, 'doing_it_wrong should capture a message.');
+            $this->assertStringContainsString($temp_dir, $captured_doing_it_wrong_message, 'doing_it_wrong should mention the failing path.');
+        } finally {
+            remove_action('doing_it_wrong_run', $listener, 10);
+
+            if (is_dir($temp_dir)) {
+                rmdir($temp_dir);
+            }
+
+            if (false !== $previous_error_log) {
+                ini_set('error_log', $previous_error_log);
+            }
+
+            if (file_exists($log_file)) {
+                unlink($log_file);
+            }
+        }
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . '/class-tejlg-files.php';
+
 class TEJLG_Admin {
 
     /**
@@ -248,7 +250,7 @@ class TEJLG_Admin {
         }
 
         if (!empty($theme_file['tmp_name']) && is_string($theme_file['tmp_name']) && file_exists($theme_file['tmp_name'])) {
-            @unlink($theme_file['tmp_name']);
+            TEJLG_Files::delete($theme_file['tmp_name']);
         }
 
         add_settings_error(
@@ -272,7 +274,7 @@ class TEJLG_Admin {
         }
 
         if (!empty($patterns_file['tmp_name']) && is_string($patterns_file['tmp_name']) && file_exists($patterns_file['tmp_name'])) {
-            @unlink($patterns_file['tmp_name']);
+            TEJLG_Files::delete($patterns_file['tmp_name']);
         }
 
         add_settings_error(

--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . '/class-tejlg-files.php';
+
 class TEJLG_Export {
 
     /**
@@ -282,7 +284,7 @@ class TEJLG_Export {
         $handle = fopen($temp_file, 'w');
 
         if (false === $handle) {
-            @unlink($temp_file);
+            TEJLG_Files::delete($temp_file);
             wp_die(esc_html__("Impossible de créer le flux de téléchargement pour l'export JSON.", 'theme-export-jlg'));
         }
 
@@ -325,7 +327,7 @@ class TEJLG_Export {
 
                 if (false === $encoded_pattern || (function_exists('json_last_error') && json_last_error() !== JSON_ERROR_NONE)) {
                     fclose($handle);
-                    @unlink($temp_file);
+                    TEJLG_Files::delete($temp_file);
 
                     $json_error_message = function_exists('json_last_error_msg')
                         ? json_last_error_msg()
@@ -440,7 +442,7 @@ class TEJLG_Export {
             return true;
         }
 
-        if (@unlink($file_path)) {
+        if (TEJLG_Files::delete($file_path)) {
             return true;
         }
 
@@ -546,7 +548,7 @@ class TEJLG_Export {
         $bytes = file_put_contents($temp_file, $json_data);
 
         if (false === $bytes) {
-            @unlink($temp_file);
+            TEJLG_Files::delete($temp_file);
 
             add_settings_error(
                 'tejlg_admin_messages',
@@ -807,7 +809,7 @@ class TEJLG_Export {
         $bytes = file_put_contents($temp_file, $json_data);
 
         if (false === $bytes) {
-            @unlink($temp_file);
+            TEJLG_Files::delete($temp_file);
             wp_die(esc_html__("Impossible d'écrire le fichier d'export JSON sur le disque.", 'theme-export-jlg'));
         }
 
@@ -837,7 +839,7 @@ class TEJLG_Export {
 
     private static function stream_json_file($file_path, $filename) {
         if (!@file_exists($file_path) || !is_readable($file_path)) {
-            @unlink($file_path);
+            TEJLG_Files::delete($file_path);
             wp_die(esc_html__("Le fichier d'export JSON est introuvable ou illisible.", 'theme-export-jlg'));
         }
 
@@ -845,7 +847,7 @@ class TEJLG_Export {
 
         if (!$should_stream) {
             $contents = @file_get_contents($file_path);
-            @unlink($file_path);
+            TEJLG_Files::delete($file_path);
 
             return false === $contents ? '' : $contents;
         }
@@ -865,7 +867,7 @@ class TEJLG_Export {
         $handle = fopen($file_path, 'rb');
 
         if (false === $handle) {
-            @unlink($file_path);
+            TEJLG_Files::delete($file_path);
             wp_die(esc_html__("Impossible de lire le fichier d'export JSON.", 'theme-export-jlg'));
         }
 
@@ -874,7 +876,7 @@ class TEJLG_Export {
         }
 
         fclose($handle);
-        @unlink($file_path);
+        TEJLG_Files::delete($file_path);
         flush();
         exit;
     }

--- a/theme-export-jlg/includes/class-tejlg-files.php
+++ b/theme-export-jlg/includes/class-tejlg-files.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Utility helpers for filesystem operations.
+ */
+class TEJLG_Files {
+    /**
+     * Deletes a file from the filesystem, logging failures when encountered.
+     *
+     * @param string $path Absolute path to the file to delete.
+     * @return bool True when the file was deleted or does not exist, false otherwise.
+     */
+    public static function delete($path) {
+        if (empty($path)) {
+            return true;
+        }
+
+        if (!file_exists($path)) {
+            return true;
+        }
+
+        if (@unlink($path)) {
+            return true;
+        }
+
+        $message = sprintf('[Theme Export JLG] Impossible de supprimer le fichier : %s', $path);
+        error_log($message);
+
+        if (function_exists('doing_it_wrong')) {
+            $version = defined('TEJLG_VERSION') ? TEJLG_VERSION : 'unknown';
+            doing_it_wrong(__METHOD__, $message, $version);
+        }
+
+        return false;
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -1,10 +1,12 @@
 <?php
+require_once __DIR__ . '/class-tejlg-files.php';
+
 class TEJLG_Import {
 
     public static function import_theme($file) {
         if (!current_user_can('install_themes')) {
             if (isset($file['tmp_name'])) {
-                @unlink($file['tmp_name']);
+                TEJLG_Files::delete($file['tmp_name']);
             }
 
             add_settings_error(
@@ -22,7 +24,7 @@ class TEJLG_Import {
             (defined('DISALLOW_FILE_EDIT') && DISALLOW_FILE_EDIT)
         ) {
             if (isset($file['tmp_name'])) {
-                @unlink($file['tmp_name']);
+                TEJLG_Files::delete($file['tmp_name']);
             }
 
             add_settings_error(
@@ -118,7 +120,7 @@ class TEJLG_Import {
         }
 
         if (isset($file['error']) && UPLOAD_ERR_OK !== (int) $file['error']) {
-            @unlink($file['tmp_name']);
+            TEJLG_Files::delete($file['tmp_name']);
             add_settings_error(
                 'tejlg_import_messages',
                 'global_styles_import_status',
@@ -142,7 +144,7 @@ class TEJLG_Import {
         }
 
         if ($file_size > $max_size) {
-            @unlink($file['tmp_name']);
+            TEJLG_Files::delete($file['tmp_name']);
             add_settings_error(
                 'tejlg_import_messages',
                 'global_styles_import_status',
@@ -166,7 +168,7 @@ class TEJLG_Import {
         $type = isset($filetype['type']) ? (string) $filetype['type'] : '';
 
         if ('json' !== $ext || 'application/json' !== $type) {
-            @unlink($file['tmp_name']);
+            TEJLG_Files::delete($file['tmp_name']);
             add_settings_error(
                 'tejlg_import_messages',
                 'global_styles_import_invalid_type',
@@ -178,7 +180,7 @@ class TEJLG_Import {
         }
 
         if (!is_readable($file['tmp_name'])) {
-            @unlink($file['tmp_name']);
+            TEJLG_Files::delete($file['tmp_name']);
             add_settings_error(
                 'tejlg_import_messages',
                 'global_styles_import_status',
@@ -191,7 +193,7 @@ class TEJLG_Import {
 
         $json_content = file_get_contents($file['tmp_name']);
 
-        @unlink($file['tmp_name']);
+        TEJLG_Files::delete($file['tmp_name']);
 
         if (false === $json_content) {
             add_settings_error(
@@ -314,7 +316,7 @@ class TEJLG_Import {
         }
 
         if (isset($file['error']) && UPLOAD_ERR_OK !== (int) $file['error']) {
-            @unlink($file['tmp_name']);
+            TEJLG_Files::delete($file['tmp_name']);
             add_settings_error(
                 'tejlg_import_messages',
                 'patterns_import_status',
@@ -336,7 +338,7 @@ class TEJLG_Import {
         }
 
         if ($file_size > $max_size) {
-            @unlink($file['tmp_name']);
+            TEJLG_Files::delete($file['tmp_name']);
             add_settings_error(
                 'tejlg_import_messages',
                 'patterns_import_status',
@@ -360,7 +362,7 @@ class TEJLG_Import {
         $type = isset($filetype['type']) ? (string) $filetype['type'] : '';
 
         if ('json' !== $ext || 'application/json' !== $type) {
-            @unlink($file['tmp_name']);
+            TEJLG_Files::delete($file['tmp_name']);
             add_settings_error(
                 'tejlg_import_messages',
                 'patterns_import_invalid_type',
@@ -372,7 +374,7 @@ class TEJLG_Import {
         }
 
         if (!is_readable($file['tmp_name'])) {
-            @unlink($file['tmp_name']);
+            TEJLG_Files::delete($file['tmp_name']);
             add_settings_error(
                 'tejlg_import_messages',
                 'patterns_import_status',
@@ -386,7 +388,7 @@ class TEJLG_Import {
         $json_content = file_get_contents($file['tmp_name']);
 
         if (false === $json_content) {
-            @unlink($file['tmp_name']);
+            TEJLG_Files::delete($file['tmp_name']);
             add_settings_error(
                 'tejlg_import_messages',
                 'patterns_import_status',
@@ -397,7 +399,7 @@ class TEJLG_Import {
             return;
         }
 
-        @unlink($file['tmp_name']);
+        TEJLG_Files::delete($file['tmp_name']);
 
         $patterns = json_decode($json_content, true);
 
@@ -1046,7 +1048,7 @@ class TEJLG_Import {
         $bytes_written = file_put_contents($temp_file, $encoded);
 
         if (false === $bytes_written) {
-            @unlink($temp_file);
+            TEJLG_Files::delete($temp_file);
 
             return new WP_Error(
                 'tejlg_import_temp_file_write_error',
@@ -1141,7 +1143,7 @@ class TEJLG_Import {
             $path = isset($storage['path']) ? (string) $storage['path'] : '';
 
             if ('' !== $path && @file_exists($path)) {
-                @unlink($path);
+                TEJLG_Files::delete($path);
             }
         }
     }
@@ -1208,7 +1210,7 @@ class TEJLG_Import {
                 continue;
             }
 
-            @unlink($file);
+            TEJLG_Files::delete($file);
         }
     }
 

--- a/theme-export-jlg/theme-export-jlg.php
+++ b/theme-export-jlg/theme-export-jlg.php
@@ -24,6 +24,7 @@ define( 'TEJLG_PATH', plugin_dir_path( __FILE__ ) );
 define( 'TEJLG_URL', plugin_dir_url( __FILE__ ) );
 
 // Charger les classes nécessaires
+require_once TEJLG_PATH . 'includes/class-tejlg-files.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-admin.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-export.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-import.php';


### PR DESCRIPTION
## Summary
- add a TEJLG_Files::delete helper that wraps unlink and reports failures
- replace direct unlink usages in admin, export, and import workflows with the helper
- cover the failure logging with a new unit test simulating an unlink error

## Testing
- npm run test:php *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da7a2ca7c4832e9b7fcdc4dee4ec5c