### PR TITLE
Sanitize export tab action handling and add regression test

### DIFF
--- a/tests/test-admin-export-tab.php
+++ b/tests/test-admin-export-tab.php
@@ -1,0 +1,56 @@
+<?php
+
+use RuntimeException;
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-admin.php';
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-import.php';
+
+/**
+ * @group admin
+ */
+class Test_Admin_Export_Tab extends WP_UnitTestCase {
+
+    public function test_render_export_tab_handles_array_action_without_warning() {
+        $admin = new TEJLG_Admin();
+
+        $_GET['action'] = ['select_patterns'];
+
+        $error_handler = static function ($errno, $errstr) {
+            if (E_WARNING === $errno || E_USER_WARNING === $errno) {
+                throw new RuntimeException($errstr);
+            }
+
+            return false;
+        };
+
+        set_error_handler($error_handler);
+
+        $output = '';
+
+        try {
+            $reflection = new ReflectionMethod(TEJLG_Admin::class, 'render_export_tab');
+            $reflection->setAccessible(true);
+
+            ob_start();
+            $reflection->invoke($admin);
+            $output = ob_get_clean();
+        } finally {
+            restore_error_handler();
+
+            unset($_GET['action']);
+        }
+
+        $this->assertStringContainsString(
+            'Exporter le Thème Actif',
+            $output,
+            'Default export tools should be displayed when action is invalid.'
+        );
+
+        $this->assertStringNotContainsString(
+            'Exporter une sélection de compositions',
+            $output,
+            'Pattern selection page should not be rendered when action is invalid.'
+        );
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -448,7 +448,15 @@ class TEJLG_Admin {
     }
 
     private function render_export_tab() {
-        if (isset($_GET['action']) && $_GET['action'] === 'select_patterns') {
+        $action_param = filter_input(INPUT_GET, 'action', FILTER_DEFAULT);
+
+        if (null === $action_param && isset($_GET['action'])) {
+            $action_param = $_GET['action'];
+        }
+
+        $action = is_string($action_param) ? sanitize_key($action_param) : '';
+
+        if ('select_patterns' === $action) {
             $this->render_pattern_selection_page();
         } else {
             $this->render_export_default_page();


### PR DESCRIPTION
## Summary
- sanitize the export tab action query parameter before selecting the export view
- add a regression test that covers array-based action inputs to ensure the default export tools render without warnings

## Testing
- npm run test:php *(fails: phpunit: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dac8398518832e911fba07cd21f983