### PR TITLE
Add WP-CLI command to export themes and patterns

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,15 @@ Theme Export - JLG est un plugin WordPress pour administrateurs de sites blocs q
 - **Améliorer l’ergonomie** grâce à des scripts dédiés : sélection/désélection en masse, accordéons de débogage, confirmation de remplacement pour l’import de thèmes et bascule d’affichage du code des compositions.【F:theme-export-jlg/assets/js/admin-scripts.js†L1-L69】
 - **Nettoyer les données temporaires** créées pendant les imports (transients) lors de la désinstallation du plugin.【F:theme-export-jlg/uninstall.php†L1-L35】
 
+## Utilisation en ligne de commande (WP-CLI)
+
+Le plugin enregistre la commande `wp theme-export-jlg` dès que WP-CLI est disponible.【F:theme-export-jlg/includes/class-tejlg-cli.php†L7-L168】 Elle propose deux sous-commandes :
+
+- `wp theme-export-jlg theme [--exclusions=<motifs>] [--output=<chemin>]` exporte le thème actif au format ZIP. Utilisez l’option `--exclusions` pour ignorer des fichiers ou dossiers (séparateur virgule ou retour à la ligne) et `--output` pour définir le chemin du fichier généré (par défaut dans le dossier courant, avec le slug du thème).【F:theme-export-jlg/includes/class-tejlg-cli.php†L17-L98】
+- `wp theme-export-jlg patterns [--portable] [--output=<chemin>]` crée un export JSON des compositions (`wp_block`). L’option `--portable` active le nettoyage portable déjà proposé dans l’interface graphique et `--output` contrôle l’emplacement du fichier généré.【F:theme-export-jlg/includes/class-tejlg-cli.php†L100-L160】
+
+Chaque commande renvoie un message de réussite structuré ou un message d’erreur explicite en cas de problème (dossier non accessible, erreur `wp_die`, etc.), pour s’intégrer facilement dans des scripts d’automatisation.【F:theme-export-jlg/includes/class-tejlg-cli.php†L40-L160】
+
 ## Support & ressources
 
 ### FAQ

--- a/tests/test-cli-command.php
+++ b/tests/test-cli-command.php
@@ -1,0 +1,104 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+
+if (!defined('WP_CLI')) {
+    define('WP_CLI', true);
+}
+
+if (!class_exists('WP_CLI')) {
+    class WP_CLI {
+        public static $commands = [];
+        public static $success_message = '';
+        public static $error_message = '';
+        public static $last_log = '';
+        public static $last_warning = '';
+
+        public static function add_command($name, $callable) {
+            self::$commands[$name] = $callable;
+        }
+
+        public static function success($message) {
+            self::$success_message = (string) $message;
+        }
+
+        public static function error($message) {
+            if ($message instanceof WP_Error) {
+                $message = $message->get_error_message();
+            }
+
+            self::$error_message = (string) $message;
+            throw new RuntimeException(self::$error_message);
+        }
+
+        public static function log($message) {
+            self::$last_log = (string) $message;
+        }
+
+        public static function warning($message) {
+            self::$last_warning = (string) $message;
+        }
+    }
+}
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-cli.php';
+
+class Test_TEJLG_CLI_Command extends WP_UnitTestCase {
+    private $export_dir;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $uploads = wp_get_upload_dir();
+        $this->export_dir = trailingslashit($uploads['basedir']) . 'tejlg-cli-tests';
+        wp_mkdir_p($this->export_dir);
+
+        WP_CLI::$success_message = '';
+        WP_CLI::$error_message = '';
+    }
+
+    protected function tearDown(): void {
+        $this->remove_directory($this->export_dir);
+        parent::tearDown();
+    }
+
+    public function test_command_is_registered() {
+        $this->assertArrayHasKey('theme-export-jlg', WP_CLI::$commands);
+    }
+
+    public function test_patterns_command_writes_json_file() {
+        $target = trailingslashit($this->export_dir) . 'patterns-cli.json';
+
+        $cli = new TEJLG_CLI();
+        $cli->patterns([], ['output' => $target, 'portable' => true]);
+
+        $this->assertFileExists($target);
+        $contents = file_get_contents($target);
+        $this->assertNotFalse($contents);
+        $decoded = json_decode($contents, true);
+        $this->assertNotNull($decoded, 'JSON should decode even if empty array.');
+        $this->assertNotSame('', WP_CLI::$success_message, 'CLI should return a success message.');
+        $this->assertStringContainsString($target, WP_CLI::$success_message);
+    }
+
+    private function remove_directory($directory) {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $entries = array_diff(scandir($directory), ['.', '..']);
+
+        foreach ($entries as $entry) {
+            $path = $directory . '/' . $entry;
+
+            if (is_dir($path)) {
+                $this->remove_directory($path);
+                continue;
+            }
+
+            @unlink($path);
+        }
+
+        @rmdir($directory);
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-cli.php
+++ b/theme-export-jlg/includes/class-tejlg-cli.php
@@ -1,0 +1,278 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('TEJLG_CLI_WPDie_Exception')) {
+    class TEJLG_CLI_WPDie_Exception extends RuntimeException {
+    }
+}
+
+class TEJLG_CLI {
+
+    public function __invoke($args, $assoc_args) {
+        WP_CLI::log(__('Commandes disponibles :', 'theme-export-jlg'));
+        WP_CLI::log('  wp theme-export-jlg theme [--exclusions=<motifs>] [--output=<chemin>]');
+        WP_CLI::log('  wp theme-export-jlg patterns [--portable] [--output=<chemin>]');
+    }
+
+    public function theme($args, $assoc_args) {
+        $exclusions = $this->parse_exclusions($assoc_args);
+        $default_filename = $this->get_theme_slug() . '.zip';
+        $output_path = $this->resolve_output_path($assoc_args, $default_filename);
+
+        $result_data = null;
+        $stream_filter = static function ($should_stream, $zip_file_path, $zip_file_name, $zip_file_size) use (&$result_data) {
+            $result_data = [
+                'path'     => $zip_file_path,
+                'filename' => $zip_file_name,
+                'size'     => $zip_file_size,
+            ];
+
+            return false;
+        };
+
+        add_filter('tejlg_export_stream_zip_archive', $stream_filter, 10, 4);
+
+        try {
+            $result = $this->capture_wp_die(static function () use ($exclusions) {
+                return TEJLG_Export::export_theme($exclusions);
+            });
+        } catch (TEJLG_CLI_WPDie_Exception $exception) {
+            remove_filter('tejlg_export_stream_zip_archive', $stream_filter, 10);
+            WP_CLI::error($this->normalize_cli_message($exception->getMessage()));
+            return;
+        }
+
+        remove_filter('tejlg_export_stream_zip_archive', $stream_filter, 10);
+
+        if (is_array($result) && isset($result['path'])) {
+            $result_data = $result;
+        }
+
+        if (empty($result_data) || empty($result_data['path'])) {
+            WP_CLI::error(__('Impossible de récupérer le fichier ZIP généré.', 'theme-export-jlg'));
+            return;
+        }
+
+        $source_path = $result_data['path'];
+
+        if (!file_exists($source_path)) {
+            WP_CLI::error(sprintf(__('Le fichier ZIP généré est introuvable : %s', 'theme-export-jlg'), $source_path));
+            return;
+        }
+
+        if (!$this->copy_file($source_path, $output_path)) {
+            @unlink($source_path);
+            WP_CLI::error(sprintf(__('Impossible de copier le fichier ZIP vers %s.', 'theme-export-jlg'), $output_path));
+            return;
+        }
+
+        @unlink($source_path);
+
+        WP_CLI::success(sprintf(__('Archive du thème exportée vers %s', 'theme-export-jlg'), $output_path));
+    }
+
+    public function patterns($args, $assoc_args) {
+        $is_portable = $this->get_bool_flag($assoc_args, 'portable');
+        $default_filename = $this->get_theme_slug() . '-patterns.json';
+        $output_path = $this->resolve_output_path($assoc_args, $default_filename);
+
+        $stream_filter = static function () {
+            return false;
+        };
+
+        add_filter('tejlg_export_stream_json_file', $stream_filter, 10, 3);
+
+        try {
+            $contents = $this->capture_wp_die(static function () use ($is_portable) {
+                return TEJLG_Export::export_patterns_json([], $is_portable);
+            });
+        } catch (TEJLG_CLI_WPDie_Exception $exception) {
+            remove_filter('tejlg_export_stream_json_file', $stream_filter, 10);
+            WP_CLI::error($this->normalize_cli_message($exception->getMessage()));
+            return;
+        }
+
+        remove_filter('tejlg_export_stream_json_file', $stream_filter, 10);
+
+        if (!is_string($contents)) {
+            WP_CLI::error(__('Le contenu JSON généré est invalide.', 'theme-export-jlg'));
+            return;
+        }
+
+        if (false === file_put_contents($output_path, $contents)) {
+            WP_CLI::error(sprintf(__('Impossible d\'écrire le fichier JSON vers %s.', 'theme-export-jlg'), $output_path));
+            return;
+        }
+
+        WP_CLI::success(sprintf(__('Fichier JSON des compositions exporté vers %s', 'theme-export-jlg'), $output_path));
+    }
+
+    private function parse_exclusions($assoc_args) {
+        if (!isset($assoc_args['exclusions'])) {
+            return [];
+        }
+
+        $raw_exclusions = $assoc_args['exclusions'];
+
+        if (is_array($raw_exclusions)) {
+            $raw_exclusions = implode(',', $raw_exclusions);
+        }
+
+        $split = preg_split('/[,\n]+/', (string) $raw_exclusions);
+
+        if (false === $split) {
+            return [];
+        }
+
+        $exclusions = array_filter(
+            array_map(
+                static function ($pattern) {
+                    return trim((string) $pattern);
+                },
+                $split
+            ),
+            static function ($pattern) {
+                return '' !== $pattern;
+            }
+        );
+
+        return array_values($exclusions);
+    }
+
+    private function resolve_output_path($assoc_args, $default_filename) {
+        $provided = isset($assoc_args['output']) ? (string) $assoc_args['output'] : '';
+        $provided = trim($provided);
+
+        if ('' === $provided) {
+            $directory = $this->normalize_path(getcwd());
+            $this->ensure_directory_exists($directory);
+
+            return trailingslashit($directory) . $default_filename;
+        }
+
+        $normalized = $this->normalize_path($provided);
+
+        if (!path_is_absolute($normalized)) {
+            $base = $this->normalize_path(getcwd());
+            $normalized = trailingslashit($base) . ltrim($normalized, '/');
+        }
+
+        $looks_like_directory = $this->path_ends_with_directory_separator($provided) || is_dir($normalized);
+
+        if ($looks_like_directory) {
+            $directory = untrailingslashit($normalized);
+            if ('' === $directory) {
+                $directory = $this->normalize_path(getcwd());
+            }
+            $this->ensure_directory_exists($directory);
+
+            return trailingslashit($directory) . $default_filename;
+        }
+
+        $directory = $this->normalize_path(dirname($normalized));
+        $this->ensure_directory_exists($directory);
+
+        return $normalized;
+    }
+
+    private function ensure_directory_exists($directory) {
+        if ('' === $directory) {
+            $directory = $this->normalize_path(getcwd());
+        }
+
+        if (!file_exists($directory)) {
+            if (!wp_mkdir_p($directory)) {
+                WP_CLI::error(sprintf(__('Impossible de créer le dossier cible : %s', 'theme-export-jlg'), $directory));
+            }
+        }
+
+        if (!is_dir($directory)) {
+            WP_CLI::error(sprintf(__('Le chemin cible n\'est pas un dossier valide : %s', 'theme-export-jlg'), $directory));
+        }
+
+        if (!is_writable($directory)) {
+            WP_CLI::error(sprintf(__('Le dossier cible n\'est pas accessible en écriture : %s', 'theme-export-jlg'), $directory));
+        }
+    }
+
+    private function copy_file($source, $destination) {
+        $bytes = @copy($source, $destination);
+
+        if (!$bytes) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function capture_wp_die(callable $callback) {
+        $handler = static function () {
+            return static function ($message) {
+                throw new TEJLG_CLI_WPDie_Exception($message);
+            };
+        };
+
+        add_filter('wp_die_handler', $handler);
+
+        try {
+            return $callback();
+        } finally {
+            remove_filter('wp_die_handler', $handler);
+        }
+    }
+
+    private function normalize_cli_message($message) {
+        if ($message instanceof WP_Error) {
+            $message = $message->get_error_message();
+        }
+
+        return trim(wp_strip_all_tags((string) $message));
+    }
+
+    private function get_bool_flag($assoc_args, $key) {
+        if (!isset($assoc_args[$key])) {
+            return false;
+        }
+
+        $value = $assoc_args[$key];
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $value = strtolower((string) $value);
+
+        return in_array($value, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function path_ends_with_directory_separator($path) {
+        if ('' === $path) {
+            return false;
+        }
+
+        $last_character = substr($path, -1);
+
+        return '/' === $last_character || '\\' === $last_character;
+    }
+
+    private function normalize_path($path) {
+        return wp_normalize_path($path);
+    }
+
+    private function get_theme_slug() {
+        $theme = wp_get_theme();
+        $slug = $theme->get_stylesheet();
+
+        if ('' === $slug) {
+            $slug = 'theme-export';
+        }
+
+        return sanitize_key($slug);
+    }
+}
+
+if (class_exists('WP_CLI')) {
+    WP_CLI::add_command('theme-export-jlg', 'TEJLG_CLI');
+}

--- a/theme-export-jlg/theme-export-jlg.php
+++ b/theme-export-jlg/theme-export-jlg.php
@@ -29,6 +29,10 @@ require_once TEJLG_PATH . 'includes/class-tejlg-export.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-import.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-theme-tools.php';
 
+if (defined('WP_CLI') && WP_CLI) {
+    require_once TEJLG_PATH . 'includes/class-tejlg-cli.php';
+}
+
 /**
  * Fonction principale pour initialiser le plugin.
  */


### PR DESCRIPTION
## Summary
- add a WP-CLI command that exposes `theme` and `patterns` exports with options for exclusions, portability and output paths
- extend the export helper to allow integrations to intercept the ZIP archive instead of forcing a stream
- document the new CLI workflow and cover it with a PHPUnit test that exercises the JSON export branch

## Testing
- `npm run test:php` *(fails: phpunit not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad6e7d80c832eb32fe604ac8eaa60