### PR TITLE
Add live performance metrics badge updates

### DIFF
--- a/tests/e2e/performance-metrics.spec.js
+++ b/tests/e2e/performance-metrics.spec.js
@@ -1,0 +1,33 @@
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+
+test.describe('Performance metrics badge', () => {
+  test('updates FPS and latency metrics with accessible output', async ({ admin, page, requestUtils }) => {
+    await requestUtils.activatePlugin('theme-export-jlg/theme-export-jlg.php');
+
+    await admin.visitAdminPage('admin.php', 'page=theme-export-jlg&tab=debug');
+
+    const fpsMetric = page.locator('#tejlg-metric-fps');
+    const latencyMetric = page.locator('#tejlg-metric-latency');
+
+    await expect(fpsMetric).toHaveAttribute('aria-live', /polite|assertive/i);
+    await expect(latencyMetric).toHaveAttribute('aria-live', /polite|assertive/i);
+
+    const fpsText = await expect.poll(
+      async () => (await fpsMetric.textContent())?.trim() || '',
+      {
+        timeout: 10000,
+        message: 'Expected FPS metric to display a numeric value',
+      }
+    );
+    expect(fpsText).toMatch(/\d/);
+
+    const latencyText = await expect.poll(
+      async () => (await latencyMetric.textContent())?.trim() || '',
+      {
+        timeout: 10000,
+        message: 'Expected latency metric to display a numeric value',
+      }
+    );
+    expect(latencyText).toMatch(/\d/);
+  });
+});

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -220,4 +220,252 @@ document.addEventListener('DOMContentLoaded', function() {
         patternSearchInput.addEventListener('keyup', searchHandler);
     }
 
+    // Mettre à jour en continu les métriques de performance dans le badge.
+    const fpsElement = document.getElementById('tejlg-metric-fps');
+    const latencyElement = document.getElementById('tejlg-metric-latency');
+
+    if (fpsElement && latencyElement) {
+        const metricsLocalization = (typeof localization.metrics === 'object' && localization.metrics !== null)
+            ? localization.metrics
+            : {};
+
+        const locale = typeof metricsLocalization.locale === 'string' && metricsLocalization.locale
+            ? metricsLocalization.locale
+            : undefined;
+
+        const fpsUnit = typeof metricsLocalization.fpsUnit === 'string' && metricsLocalization.fpsUnit.trim() !== ''
+            ? metricsLocalization.fpsUnit
+            : 'FPS';
+
+        const latencyUnit = typeof metricsLocalization.latencyUnit === 'string' && metricsLocalization.latencyUnit.trim() !== ''
+            ? metricsLocalization.latencyUnit
+            : 'ms';
+
+        const placeholderText = typeof metricsLocalization.placeholder === 'string' && metricsLocalization.placeholder !== ''
+            ? metricsLocalization.placeholder
+            : '--';
+
+        const stoppedText = typeof metricsLocalization.stopped === 'string' && metricsLocalization.stopped !== ''
+            ? metricsLocalization.stopped
+            : '⏹';
+
+        const loadingText = typeof metricsLocalization.loading === 'string' && metricsLocalization.loading !== ''
+            ? metricsLocalization.loading
+            : placeholderText;
+
+        const ariaLiveValue = typeof metricsLocalization.ariaLivePolite === 'string' && metricsLocalization.ariaLivePolite !== ''
+            ? metricsLocalization.ariaLivePolite
+            : 'polite';
+
+        const ariaAtomicValue = typeof metricsLocalization.ariaAtomic === 'string' && metricsLocalization.ariaAtomic !== ''
+            ? metricsLocalization.ariaAtomic
+            : 'true';
+
+        const latencyPrecision = typeof metricsLocalization.latencyPrecision === 'number' && metricsLocalization.latencyPrecision >= 0
+            ? metricsLocalization.latencyPrecision
+            : 1;
+
+        fpsElement.setAttribute('aria-live', ariaLiveValue);
+        fpsElement.setAttribute('aria-atomic', ariaAtomicValue);
+        latencyElement.setAttribute('aria-live', ariaLiveValue);
+        latencyElement.setAttribute('aria-atomic', ariaAtomicValue);
+
+        fpsElement.textContent = loadingText;
+        latencyElement.textContent = loadingText;
+
+        const idealFrameDuration = 1000 / 60;
+        const maxSampleSize = 120;
+        const maxFrameGap = 1500;
+
+        const fpsSamples = [];
+        const latencySamplesFromRaf = [];
+        const latencySamplesFromObserver = [];
+
+        let animationFrameId = null;
+        let lastFrameTime;
+        let monitoringActive = true;
+        let performanceObserverInstance = null;
+
+        const hasIntl = typeof window.Intl === 'object' && typeof window.Intl.NumberFormat === 'function';
+        const fpsFormatter = hasIntl
+            ? new window.Intl.NumberFormat(locale, { maximumFractionDigits: 0, minimumFractionDigits: 0 })
+            : null;
+        const latencyFormatter = hasIntl
+            ? new window.Intl.NumberFormat(locale, { maximumFractionDigits: latencyPrecision, minimumFractionDigits: 0 })
+            : null;
+
+        const pushSample = function(samples, value) {
+            samples.push(value);
+            if (samples.length > maxSampleSize) {
+                samples.shift();
+            }
+        };
+
+        const computeAverage = function(samples) {
+            if (!samples.length) {
+                return null;
+            }
+
+            var total = 0;
+            for (var i = 0; i < samples.length; i += 1) {
+                total += samples[i];
+            }
+
+            return total / samples.length;
+        };
+
+        const formatValue = function(value, formatter, fallbackDigits) {
+            if (typeof value !== 'number' || !isFinite(value)) {
+                return placeholderText;
+            }
+
+            if (formatter) {
+                return formatter.format(value);
+            }
+
+            var digits = Math.max(0, fallbackDigits);
+            return value.toFixed(digits);
+        };
+
+        const updateDisplay = function() {
+            if (!monitoringActive) {
+                return;
+            }
+
+            const averageFps = computeAverage(fpsSamples);
+            if (averageFps === null) {
+                fpsElement.textContent = placeholderText;
+            } else {
+                const fpsText = formatValue(averageFps, fpsFormatter, 0);
+                fpsElement.textContent = fpsUnit ? fpsText + '\u00a0' + fpsUnit : fpsText;
+            }
+
+            const observerLatency = computeAverage(latencySamplesFromObserver);
+            const rafLatency = computeAverage(latencySamplesFromRaf);
+            const latencyToDisplay = observerLatency !== null ? observerLatency : rafLatency;
+
+            if (latencyToDisplay === null) {
+                latencyElement.textContent = placeholderText;
+            } else {
+                const latencyText = formatValue(latencyToDisplay, latencyFormatter, latencyPrecision);
+                latencyElement.textContent = latencyUnit ? latencyText + '\u00a0' + latencyUnit : latencyText;
+            }
+        };
+
+        const onAnimationFrame = function(timestamp) {
+            if (!monitoringActive) {
+                return;
+            }
+
+            if (typeof lastFrameTime === 'number') {
+                var frameDelta = timestamp - lastFrameTime;
+
+                if (frameDelta > 0 && frameDelta < maxFrameGap) {
+                    pushSample(fpsSamples, 1000 / frameDelta);
+                    var latencyValue = frameDelta - idealFrameDuration;
+                    if (latencyValue < 0) {
+                        latencyValue = 0;
+                    }
+                    pushSample(latencySamplesFromRaf, latencyValue);
+                }
+            }
+
+            lastFrameTime = timestamp;
+            updateDisplay();
+            animationFrameId = window.requestAnimationFrame(onAnimationFrame);
+        };
+
+        const setupPerformanceObserver = function() {
+            if (typeof window.PerformanceObserver !== 'function') {
+                return;
+            }
+
+            const supportedEntryTypes = Array.isArray(window.PerformanceObserver.supportedEntryTypes)
+                ? window.PerformanceObserver.supportedEntryTypes
+                : [];
+
+            var observerType = '';
+            if (supportedEntryTypes.indexOf('event') !== -1) {
+                observerType = 'event';
+            } else if (supportedEntryTypes.indexOf('longtask') !== -1) {
+                observerType = 'longtask';
+            }
+
+            if (!observerType) {
+                return;
+            }
+
+            try {
+                performanceObserverInstance = new window.PerformanceObserver(function(list) {
+                    const entries = list.getEntries();
+                    for (var i = 0; i < entries.length; i += 1) {
+                        var entry = entries[i];
+                        var duration = 0;
+
+                        if (observerType === 'event') {
+                            if (typeof entry.duration === 'number' && entry.duration > 0) {
+                                duration = entry.duration;
+                            } else if (
+                                typeof entry.processingEnd === 'number' &&
+                                typeof entry.startTime === 'number'
+                            ) {
+                                duration = entry.processingEnd - entry.startTime;
+                            }
+                        } else if (observerType === 'longtask') {
+                            duration = entry.duration;
+                        }
+
+                        if (duration > 0) {
+                            pushSample(latencySamplesFromObserver, duration);
+                        }
+                    }
+
+                    updateDisplay();
+                });
+
+                if (observerType === 'event') {
+                    performanceObserverInstance.observe({ type: 'event', buffered: true, durationThreshold: 0 });
+                } else {
+                    performanceObserverInstance.observe({ type: 'longtask', buffered: true });
+                }
+            } catch (error) {
+                performanceObserverInstance = null;
+            }
+        };
+
+        const stopMonitoring = function() {
+            if (!monitoringActive) {
+                return;
+            }
+
+            monitoringActive = false;
+
+            if (animationFrameId !== null) {
+                window.cancelAnimationFrame(animationFrameId);
+                animationFrameId = null;
+            }
+
+            if (performanceObserverInstance) {
+                try {
+                    performanceObserverInstance.disconnect();
+                } catch (error) {
+                    // Ignorer les erreurs de déconnexion.
+                }
+                performanceObserverInstance = null;
+            }
+
+            lastFrameTime = undefined;
+            fpsSamples.length = 0;
+            latencySamplesFromRaf.length = 0;
+            latencySamplesFromObserver.length = 0;
+
+            fpsElement.textContent = stoppedText;
+            latencyElement.textContent = stoppedText;
+        };
+
+        setupPerformanceObserver();
+        animationFrameId = window.requestAnimationFrame(onAnimationFrame);
+        window.addEventListener('beforeunload', stopMonitoring, { once: true });
+    }
+
 });

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -54,6 +54,17 @@ class TEJLG_Admin {
                 'hideBlockCode' => __('Masquer le code du bloc', 'theme-export-jlg'),
                 /* translators: Warning shown before importing a theme zip file. */
                 'themeImportConfirm' => __("⚠️ ATTENTION ⚠️\n\nSi un thème avec le même nom de dossier existe déjà, il sera DÉFINITIVEMENT écrasé.\n\nÊtes-vous sûr de vouloir continuer ?", 'theme-export-jlg'),
+                'metrics' => [
+                    'locale'           => get_user_locale(),
+                    'fpsUnit'          => esc_html__('FPS', 'theme-export-jlg'),
+                    'latencyUnit'      => esc_html__('ms', 'theme-export-jlg'),
+                    'placeholder'      => esc_html__('--', 'theme-export-jlg'),
+                    'stopped'          => esc_html__('Arrêté', 'theme-export-jlg'),
+                    'loading'          => esc_html__('Initialisation…', 'theme-export-jlg'),
+                    'ariaLivePolite'   => 'polite',
+                    'ariaAtomic'       => 'true',
+                    'latencyPrecision' => 1,
+                ],
             ]
         );
     }


### PR DESCRIPTION
## Summary
- add localized configuration for the admin performance badge
- compute live FPS and latency values with a PerformanceObserver/requestAnimationFrame fallback and aria-live updates
- cover the badge behaviour with an end-to-end Playwright test

## Testing
- npm run test:e2e *(fails: host system is missing Playwright runtime dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dad6aa8cb8832e85be7a573e899167