### PR TITLE
Implement asynchronous background processing for theme export

### DIFF
--- a/tests/test-admin-export-tab.php
+++ b/tests/test-admin-export-tab.php
@@ -2,9 +2,14 @@
 
 use RuntimeException;
 
-require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-admin.php';
-require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
-require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-import.php';
+if (!defined('TEJLG_PATH')) {
+    define('TEJLG_PATH', dirname(__DIR__) . '/theme-export-jlg/');
+}
+
+require_once TEJLG_PATH . 'includes/class-tejlg-theme-export-process.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-admin.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-export.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-import.php';
 
 /**
  * @group admin

--- a/tests/test-cli-command.php
+++ b/tests/test-cli-command.php
@@ -1,6 +1,11 @@
 <?php
 
-require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+if (!defined('TEJLG_PATH')) {
+    define('TEJLG_PATH', dirname(__DIR__) . '/theme-export-jlg/');
+}
+
+require_once TEJLG_PATH . 'includes/class-tejlg-theme-export-process.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-export.php';
 
 if (!defined('WP_CLI')) {
     define('WP_CLI', true);

--- a/tests/test-export-theme.php
+++ b/tests/test-export-theme.php
@@ -1,45 +1,80 @@
 <?php
 
-require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+if (!defined('TEJLG_PATH')) {
+    define('TEJLG_PATH', dirname(__DIR__) . '/theme-export-jlg/');
+}
+
+require_once TEJLG_PATH . 'includes/class-tejlg-theme-export-process.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-export.php';
 
 /**
  * @group export-theme
  */
 class Test_Export_Theme extends WP_UnitTestCase {
 
-    public function test_export_theme_dies_when_filesize_is_unavailable() {
+    public function test_export_theme_job_returns_status_after_completion() {
+        $job_id = TEJLG_Export::export_theme([], ['dispatch' => false]);
+
+        $this->assertIsString($job_id, 'Export should return a job identifier.');
+
+        while (true) {
+            $result = TEJLG_Export::process_theme_export_job($job_id);
+
+            if (false === $result) {
+                break;
+            }
+        }
+
+        $status = TEJLG_Export::get_theme_export_status($job_id);
+
+        $this->assertIsArray($status, 'Status data should be returned as an array.');
+        $this->assertSame('completed', $status['status'], 'The job should report a completed status.');
+        $this->assertTrue($status['downloadReady'], 'The job should be flagged as ready for download.');
+        $this->assertNotEmpty($status['zipFilename'], 'The ZIP filename should be provided.');
+        $this->assertGreaterThan(0, $status['zipSize'], 'The ZIP size should be greater than zero.');
+
+        $job = TEJLG_Export::get_theme_export_job($job_id);
+
+        $this->assertTrue(file_exists($job['zip_path']), 'The generated ZIP file should exist.');
+
+        TEJLG_Export::cleanup_theme_export_job($job_id);
+    }
+
+    public function test_export_theme_job_fails_when_filesize_is_unavailable() {
         $captured_temp_path = null;
-        $die_message        = null;
 
         $filesize_filter = static function ($size, $path) use (&$captured_temp_path) {
             $captured_temp_path = $path;
             return false;
         };
 
-        $wp_die_handler = static function () use (&$die_message) {
-            return static function ($message) use (&$die_message) {
-                $die_message = $message;
-                throw new WPDieException($message);
-            };
-        };
-
         add_filter('tejlg_export_zip_file_size', $filesize_filter, 10, 2);
-        add_filter('wp_die_handler', $wp_die_handler);
 
-        try {
-            TEJLG_Export::export_theme();
-            $this->fail('Expected WPDieException was not thrown.');
-        } catch (WPDieException $exception) {
-            $this->assertNotEmpty($die_message, 'The wp_die handler should capture a message.');
-            $this->assertStringContainsString(
-                "Impossible de déterminer la taille de l'archive ZIP à télécharger.",
-                wp_strip_all_tags((string) $die_message)
-            );
-            $this->assertNotEmpty($captured_temp_path, 'The temporary ZIP path should be captured.');
-            $this->assertFileDoesNotExist($captured_temp_path, 'The temporary ZIP file should be cleaned up.');
-        } finally {
-            remove_filter('tejlg_export_zip_file_size', $filesize_filter, 10);
-            remove_filter('wp_die_handler', $wp_die_handler, 10);
+        $job_id = TEJLG_Export::export_theme([], ['dispatch' => false]);
+
+        $this->assertIsString($job_id, 'Export should return a job identifier.');
+
+        while (true) {
+            $result = TEJLG_Export::process_theme_export_job($job_id);
+
+            if (false === $result) {
+                break;
+            }
         }
+
+        $job = TEJLG_Export::get_theme_export_job($job_id);
+
+        $this->assertNotNull($job, 'The job data should be available after processing.');
+        $this->assertSame('error', $job['status'], 'The job should end in an error state.');
+        $this->assertStringContainsString(
+            "Impossible de déterminer la taille de l'archive ZIP à télécharger.",
+            (string) $job['message']
+        );
+        $this->assertNotEmpty($captured_temp_path, 'The temporary ZIP path should be captured.');
+        $this->assertFileDoesNotExist($captured_temp_path, 'The temporary ZIP file should be cleaned up on failure.');
+
+        TEJLG_Export::cleanup_theme_export_job($job_id, false);
+
+        remove_filter('tejlg_export_zip_file_size', $filesize_filter, 10);
     }
 }

--- a/tests/test-pattern-sanitizer.php
+++ b/tests/test-pattern-sanitizer.php
@@ -1,8 +1,13 @@
 <?php
 
-require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-admin.php';
-require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-import.php';
-require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+if (!defined('TEJLG_PATH')) {
+    define('TEJLG_PATH', dirname(__DIR__) . '/theme-export-jlg/');
+}
+
+require_once TEJLG_PATH . 'includes/class-tejlg-theme-export-process.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-admin.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-import.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-export.php';
 
 /**
  * @group pattern-sanitizer

--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -13,6 +13,56 @@
     box-shadow: 0 1px 1px rgba(0,0,0,.04);
 }
 
+.tejlg-theme-export-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.tejlg-theme-export-status {
+    margin-top: 1em;
+    border-top: 1px solid #e0e0e0;
+    padding-top: 1em;
+}
+
+.tejlg-theme-export-status.is-hidden {
+    display: none;
+}
+
+.tejlg-theme-export-progress {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 0.5em;
+}
+
+.tejlg-theme-export-progress progress {
+    width: 100%;
+    height: 16px;
+}
+
+.tejlg-theme-export-progress-text {
+    font-weight: 600;
+}
+
+.tejlg-theme-export-message {
+    margin: 0;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.tejlg-theme-export-status.is-error .tejlg-theme-export-message {
+    color: #b32d2e;
+}
+
+.tejlg-theme-export-status.is-complete .tejlg-theme-export-message {
+    color: #007017;
+}
+
+.tejlg-theme-export-download {
+    margin-top: 1em;
+}
+
 .metrics-badge {
     display: inline-flex;
     flex-direction: column;

--- a/theme-export-jlg/includes/class-tejlg-background-process.php
+++ b/theme-export-jlg/includes/class-tejlg-background-process.php
@@ -1,0 +1,436 @@
+<?php
+/**
+ * Background processing utilities for Theme Export JLG.
+ *
+ * @package ThemeExportJLG
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WP_Async_Request', false ) ) {
+    abstract class WP_Async_Request {
+
+        /**
+         * Prefix.
+         *
+         * @var string
+         */
+        protected $prefix = 'wp';
+
+        /**
+         * Action.
+         *
+         * @var string
+         */
+        protected $action = 'async_request';
+
+        /**
+         * Identifier.
+         *
+         * @var string
+         */
+        protected $identifier = '';
+
+        /**
+         * Data.
+         *
+         * @var array
+         */
+        protected $data = [];
+
+        /**
+         * Initiate new async request.
+         */
+        public function __construct() {
+            add_action( 'admin_init', [ $this, 'maybe_handle' ] );
+            add_action( 'wp_ajax_' . $this->get_action(), [ $this, 'maybe_handle' ] );
+            add_action( 'wp_ajax_nopriv_' . $this->get_action(), [ $this, 'maybe_handle' ] );
+
+            $this->identifier = $this->prefix . '_' . $this->action;
+        }
+
+        /**
+         * Get identifier.
+         *
+         * @return string
+         */
+        public function get_identifier() {
+            return $this->prefix . '_' . $this->action;
+        }
+
+        /**
+         * Get action name.
+         *
+         * @return string
+         */
+        public function get_action() {
+            return $this->prefix . '_' . $this->action;
+        }
+
+        /**
+         * Set data.
+         *
+         * @param array $data Data.
+         *
+         * @return $this
+         */
+        public function data( array $data ) {
+            $this->data = $data;
+
+            return $this;
+        }
+
+        /**
+         * Dispatch the async request.
+         *
+         * @return array|WP_Error
+         */
+        public function dispatch() {
+            $url  = admin_url( 'admin-ajax.php' );
+            $args = [
+                'timeout'   => 0.01,
+                'blocking'  => false,
+                'body'      => $this->data,
+                'cookies'   => wp_unslash( $_COOKIE ),
+                'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
+            ];
+
+            return wp_remote_post( add_query_arg( 'action', $this->get_action(), $url ), $args );
+        }
+
+        /**
+         * Maybe handle async request.
+         */
+        public function maybe_handle() {
+            if ( ! isset( $_REQUEST['action'] ) || $this->get_action() !== $_REQUEST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                return;
+            }
+
+            $this->handle();
+            wp_die();
+        }
+
+        /**
+         * Handle.
+         */
+        abstract protected function handle();
+    }
+}
+
+if ( ! class_exists( 'WP_Background_Process', false ) ) {
+    abstract class WP_Background_Process extends WP_Async_Request {
+
+        /**
+         * Action.
+         *
+         * @var string
+         */
+        protected $action = 'background_process';
+
+        /**
+         * Start time of current process.
+         *
+         * @var int
+         */
+        protected $start_time = 0;
+
+        /**
+         * Cron hook identifier.
+         *
+         * @var string
+         */
+        protected $cron_hook_identifier;
+
+        /**
+         * Cron interval identifier.
+         *
+         * @var string
+         */
+        protected $cron_interval_identifier;
+
+        /**
+         * Initiate new background process.
+         */
+        public function __construct() {
+            parent::__construct();
+
+            $this->cron_hook_identifier     = $this->identifier . '_cron';
+            $this->cron_interval_identifier = $this->identifier . '_cron_interval';
+
+            add_action( $this->cron_hook_identifier, [ $this, 'handle_cron_healthcheck' ] );
+            add_filter( 'cron_schedules', [ $this, 'schedule_cron_healthcheck' ] );
+        }
+
+        /**
+         * Dispatch background process.
+         */
+        public function dispatch() {
+            $dispatch = parent::dispatch();
+
+            if ( is_wp_error( $dispatch ) ) {
+                return $dispatch;
+            }
+
+            if ( false === $dispatch ) {
+                return new WP_Error( 'wp_background_process_unavailable', __( 'Background processing is unavailable.', 'theme-export-jlg' ) );
+            }
+
+            $this->schedule_event();
+
+            return $dispatch;
+        }
+
+        /**
+         * Push to queue.
+         *
+         * @param mixed $data Data.
+         *
+         * @return $this
+         */
+        public function push_to_queue( $data ) {
+            $queue = $this->get_queue();
+            $queue[] = $data;
+            $this->update_queue( $queue );
+
+            return $this;
+        }
+
+        /**
+         * Save queue.
+         *
+         * @return $this
+         */
+        public function save() {
+            if ( ! $this->is_queue_empty() ) {
+                $this->dispatch();
+            }
+
+            return $this;
+        }
+
+        /**
+         * Update queue.
+         *
+         * @param array $queue Queue.
+         */
+        protected function update_queue( array $queue ) {
+            update_site_option( $this->get_queue_key(), $queue );
+        }
+
+        /**
+         * Get queue.
+         *
+         * @return array
+         */
+        protected function get_queue() {
+            $queue = get_site_option( $this->get_queue_key(), [] );
+
+            if ( ! is_array( $queue ) ) {
+                $queue = [];
+            }
+
+            return $queue;
+        }
+
+        /**
+         * Get queue option key.
+         *
+         * @return string
+         */
+        protected function get_queue_key() {
+            return $this->identifier . '_queue';
+        }
+
+        /**
+         * Is queue empty.
+         *
+         * @return bool
+         */
+        protected function is_queue_empty() {
+            $queue = $this->get_queue();
+
+            return empty( $queue );
+        }
+
+        /**
+         * Maybe handle.
+         */
+        public function maybe_handle() {
+            parent::maybe_handle();
+        }
+
+        /**
+         * Handle.
+         */
+        protected function handle() {
+            $this->handle_process();
+            $this->stop_healthcheck();
+        }
+
+        /**
+         * Handle queue.
+         */
+        protected function handle_queue() {
+            $queue = $this->get_queue();
+
+            if ( empty( $queue ) ) {
+                $this->complete();
+                $this->clear_queue();
+                return;
+            }
+
+            $this->start_time = time();
+
+            $batch = array_shift( $queue );
+            $this->update_queue( $queue );
+
+            $task = $this->task( $batch );
+
+            if ( false !== $task ) {
+                $queue = $this->get_queue();
+                $queue[] = $task;
+                $this->update_queue( $queue );
+            }
+
+            if ( ! $this->is_queue_empty() ) {
+                $this->dispatch();
+            } else {
+                $this->complete();
+                $this->clear_queue();
+            }
+        }
+
+        /**
+         * Task.
+         *
+         * @param mixed $item Queue item to iterate over.
+         *
+         * @return mixed
+         */
+        abstract protected function task( $item );
+
+        /**
+         * Complete.
+         */
+        protected function complete() {}
+
+        /**
+         * Clear queue.
+         */
+        protected function clear_queue() {
+            delete_site_option( $this->get_queue_key() );
+        }
+
+        /**
+         * Schedule event.
+         */
+        protected function schedule_event() {
+            if ( ! wp_next_scheduled( $this->cron_hook_identifier ) ) {
+                wp_schedule_event( time() + 10, $this->cron_interval_identifier, $this->cron_hook_identifier );
+            }
+        }
+
+        /**
+         * Schedule cron healthcheck.
+         *
+         * @param array $schedules Schedules.
+         *
+         * @return array
+         */
+        public function schedule_cron_healthcheck( $schedules ) {
+            $schedules[ $this->cron_interval_identifier ] = [
+                'interval' => apply_filters( $this->identifier . '_cron_interval', 5 * MINUTE_IN_SECONDS ),
+                'display'  => __( 'Every Five Minutes', 'theme-export-jlg' ),
+            ];
+
+            return $schedules;
+        }
+
+        /**
+         * Handle cron healthcheck.
+         */
+        public function handle_cron_healthcheck() {
+            if ( $this->is_process_running() ) {
+                return;
+            }
+
+            if ( $this->is_queue_empty() ) {
+                $this->stop_healthcheck();
+                return;
+            }
+
+            $this->dispatch();
+        }
+
+        /**
+         * Is process running.
+         *
+         * @return bool
+         */
+        protected function is_process_running() {
+            return (bool) get_site_transient( $this->identifier . '_process_lock' );
+        }
+
+        /**
+         * Lock process.
+         */
+        protected function lock_process() {
+            $this->start_time = time();
+            $lock_duration    = apply_filters( $this->identifier . '_queue_lock_time', 60 );
+
+            set_site_transient( $this->identifier . '_process_lock', microtime(), $lock_duration );
+        }
+
+        /**
+         * Unlock process.
+         */
+        protected function unlock_process() {
+            delete_site_transient( $this->identifier . '_process_lock' );
+        }
+
+        /**
+         * Stop healthcheck.
+         */
+        protected function stop_healthcheck() {
+            $timestamp = wp_next_scheduled( $this->cron_hook_identifier );
+
+            if ( $timestamp ) {
+                wp_unschedule_event( $timestamp, $this->cron_hook_identifier );
+            }
+        }
+
+        /**
+         * Handle queue.
+         */
+        protected function handle_process() {
+            if ( $this->is_process_running() ) {
+                if ( $this->time_exceeded() ) {
+                    $this->unlock_process();
+                } else {
+                    return;
+                }
+            }
+
+            $this->lock_process();
+            $this->handle_queue();
+            $this->unlock_process();
+        }
+
+        /**
+         * Check if the current process has exceeded the time limit.
+         *
+         * @return bool
+         */
+        protected function time_exceeded() {
+            if ( empty( $this->start_time ) ) {
+                return false;
+            }
+
+            $finish = $this->start_time + apply_filters( $this->identifier . '_queue_time_limit', 20 );
+
+            return time() > $finish;
+        }
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-theme-export-process.php
+++ b/theme-export-jlg/includes/class-tejlg-theme-export-process.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Background process for theme exports.
+ *
+ * @package ThemeExportJLG
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once TEJLG_PATH . 'includes/class-tejlg-background-process.php';
+
+class TEJLG_Theme_Export_Process extends WP_Background_Process {
+
+    /**
+     * Action identifier.
+     *
+     * @var string
+     */
+    protected $action = 'tejlg_theme_export';
+
+    /**
+     * Singleton instance.
+     *
+     * @var self|null
+     */
+    private static $instance = null;
+
+    /**
+     * Retrieve singleton instance.
+     *
+     * @return self
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Process a queue item.
+     *
+     * @param string $job_id Job identifier.
+     *
+     * @return string|false
+     */
+    protected function task( $job_id ) {
+        if ( ! is_string( $job_id ) || '' === $job_id ) {
+            return false;
+        }
+
+        return TEJLG_Export::process_theme_export_job( $job_id );
+    }
+
+    /**
+     * When the queue is completed.
+     */
+    protected function complete() {
+        parent::complete();
+    }
+}

--- a/theme-export-jlg/theme-export-jlg.php
+++ b/theme-export-jlg/theme-export-jlg.php
@@ -25,6 +25,7 @@ define( 'TEJLG_URL', plugin_dir_url( __FILE__ ) );
 
 // Charger les classes nécessaires
 require_once TEJLG_PATH . 'includes/class-tejlg-admin.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-theme-export-process.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-export.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-import.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-theme-tools.php';


### PR DESCRIPTION
## Summary
- add background processing utilities and a dedicated theme export queue to process files in batches
- refactor theme export workflow to create jobs, expose AJAX endpoints for status/download, and update admin UI + CLI handling
- enhance JavaScript and PHP unit tests to cover job lifecycle and display progress feedback

## Testing
- ⚠️ `npm run test:php` *(phpunit is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd314082c832eaba9e64abc63323d