### PR TITLE
Retain imported theme package until installation completes

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -172,18 +172,10 @@ class TEJLG_Import {
         );
 
         if (false === $filesystem_credentials) {
-            if ($file_upload instanceof File_Upload_Upgrader) {
-                $file_upload->cleanup();
-            }
-
             return;
         }
 
         if (!WP_Filesystem($filesystem_credentials, $theme_root)) {
-            if ($file_upload instanceof File_Upload_Upgrader) {
-                $file_upload->cleanup();
-            }
-
             request_filesystem_credentials($page_url, '', true, $theme_root, [$package_param]);
 
             return;


### PR DESCRIPTION
## Summary
- avoid cleaning up the uploaded archive before filesystem credentials are provided
- keep the cleanup after the theme installation attempt to handle final outcomes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbfb8b0324832e9e0cf64c03dee47e