### PR TITLE
Handle exports when WP-Cron is disabled

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,10 +37,13 @@ Chaque commande renvoie un message de réussite structuré ou un message d’err
 ## Support & ressources
 
 ### FAQ
-**Pourquoi l’export du thème échoue-t-il immédiatement ?**  
+**Pourquoi l’export du thème échoue-t-il immédiatement ?**
 L’extension vérifie la présence de `ZipArchive` avant de créer l’archive ZIP. Activez ou installez l’extension côté serveur, puis contrôlez son statut dans l’onglet Débogage.【F:theme-export-jlg/includes/class-tejlg-export.php†L7-L37】【F:theme-export-jlg/includes/class-tejlg-admin.php†L214-L236】
 
-**Puis-je réimporter un fichier de compositions sans créer de doublon ?**  
+**Et si WP-Cron est désactivé par mon hébergeur ?**
+Le plugin détecte automatiquement l’absence d’évènements planifiés ou la constante `DISABLE_WP_CRON` pour traiter immédiatement l’export, sans dépendre de WP-Cron. Vous obtenez ainsi le même comportement que sur un environnement professionnel où un cron serveur prendrait le relais.【F:theme-export-jlg/includes/class-tejlg-export.php†L103-L133】
+
+**Puis-je réimporter un fichier de compositions sans créer de doublon ?**
 Oui. Lors de la seconde étape d’import, le plugin ignore les compositions dont le slug est déjà enregistré afin d’éviter les duplications inutiles.【F:theme-export-jlg/includes/class-tejlg-import.php†L41-L70】
 
 **Que faire si la prévisualisation d’import affiche “session expirée” ?**  


### PR DESCRIPTION
## Summary
- ensure theme exports run immediately when WP-Cron is disabled or cannot schedule jobs
- add regression test covering DISABLE_WP_CRON scenarios
- document the fallback behaviour for hosts without WP-Cron

## Testing
- npm run test:php *(fails: phpunit not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc22007838832eb12ea4ee89bb94b5