### PR TITLE
Add scheduled cleanup for stale export jobs

### DIFF
--- a/theme-export-jlg/theme-export-jlg.php
+++ b/theme-export-jlg/theme-export-jlg.php
@@ -50,5 +50,6 @@ function tejlg_load_textdomain() {
 add_action('wp_ajax_tejlg_start_theme_export', ['TEJLG_Export', 'ajax_start_theme_export']);
 add_action('wp_ajax_tejlg_theme_export_status', ['TEJLG_Export', 'ajax_get_theme_export_status']);
 add_action('wp_ajax_tejlg_download_theme_export', ['TEJLG_Export', 'ajax_download_theme_export']);
+add_action('admin_init', ['TEJLG_Export', 'cleanup_stale_jobs']);
 add_action( 'plugins_loaded', 'tejlg_load_textdomain' );
 add_action( 'plugins_loaded', 'tejlg_run_plugin' );

--- a/theme-export-jlg/uninstall.php
+++ b/theme-export-jlg/uninstall.php
@@ -35,6 +35,16 @@ $wpdb->query(
     )
 );
 
+$job_option_prefix      = 'tejlg_export_job_';
+$escaped_job_option     = $wpdb->esc_like( $job_option_prefix ) . '%';
+
+$wpdb->query(
+    $wpdb->prepare(
+        "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+        $escaped_job_option
+    )
+);
+
 // Supprimer l'option stockant la taille des icônes de métriques (mono et multisites).
 delete_option( 'tejlg_metrics_icon_size' );
 delete_site_option( 'tejlg_metrics_icon_size' );


### PR DESCRIPTION
## Summary
- add a lazy cleanup routine that removes stale export jobs and their temporary files
- trigger the cleanup from admin requests, status polling, and plugin uninstall
- cover the stale job cleanup with a new PHPUnit scenario

## Testing
- npm run test:php *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc25deafa8832ea95edb866d867e6f