### PR TITLE
Add synchronous theme export fallback

### DIFF
--- a/tests/test-admin-theme-export-sync.php
+++ b/tests/test-admin-theme-export-sync.php
@@ -1,0 +1,74 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-admin.php';
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+
+/**
+ * @group admin
+ */
+class Test_Admin_Theme_Export_Sync extends WP_UnitTestCase {
+
+    public function test_theme_export_form_submission_streams_zip_when_nonce_is_valid() {
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+
+        $admin = new TEJLG_Admin();
+
+        $original_post   = $_POST;
+        $original_method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : null;
+
+        $_POST['tejlg_theme_export_nonce']   = wp_create_nonce('tejlg_theme_export_action');
+        $_POST['tejlg_exclusion_patterns']   = '';
+        $_SERVER['REQUEST_METHOD']           = 'POST';
+
+        $captured = null;
+
+        add_filter(
+            'tejlg_export_stream_zip_archive',
+            static function ($should_stream, $zip_path, $zip_file_name, $zip_file_size) use (&$captured) {
+                $captured = [
+                    'path'     => $zip_path,
+                    'filename' => $zip_file_name,
+                    'size'     => $zip_file_size,
+                ];
+
+                return false;
+            },
+            10,
+            4
+        );
+
+        $reflection = new ReflectionMethod(TEJLG_Admin::class, 'handle_theme_export_form_submission');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke($admin);
+
+        remove_all_filters('tejlg_export_stream_zip_archive');
+
+        $_POST = $original_post;
+
+        if (null === $original_method) {
+            unset($_SERVER['REQUEST_METHOD']);
+        } else {
+            $_SERVER['REQUEST_METHOD'] = $original_method;
+        }
+
+        $this->assertIsArray($result, 'Expected the handler to return zip metadata when streaming is disabled.');
+
+        $this->assertArrayHasKey('job_id', $result);
+        $this->assertArrayHasKey('path', $result);
+        $this->assertArrayHasKey('filename', $result);
+        $this->assertArrayHasKey('size', $result);
+
+        $this->assertNotEmpty($result['job_id']);
+        $this->assertNotEmpty($result['filename']);
+        $this->assertGreaterThan(0, $result['size']);
+        $this->assertFileExists($result['path']);
+
+        $this->assertIsArray($captured);
+        $this->assertSame($captured['path'], $result['path']);
+        $this->assertSame($captured['filename'], $result['filename']);
+        $this->assertSame($captured['size'], $result['size']);
+
+        TEJLG_Export::delete_job($result['job_id']);
+    }
+}

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -271,7 +271,11 @@ document.addEventListener('DOMContentLoaded', function() {
             };
 
             if (startButton) {
-                startButton.addEventListener('click', function() {
+                startButton.addEventListener('click', function(event) {
+                    if (event && typeof event.preventDefault === 'function') {
+                        event.preventDefault();
+                    }
+
                     stopPolling();
                     setSpinner(true);
                     if (startButton) {


### PR DESCRIPTION
## Summary
- convert the theme export UI into a real POST form with a dedicated nonce and submit button
- handle the new POST request server-side to trigger a synchronous theme export when JavaScript is unavailable
- keep the asynchronous flow by cancelling the form submission in the JS handler and cover the PHP path with a new unit test

## Testing
- npm run test:php *(fails: phpunit: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc354e5474832e9f3ef7c92e66aeee