### PR TITLE
Persist export job state across sessions

### DIFF
--- a/tests/e2e/theme-export-async.spec.js
+++ b/tests/e2e/theme-export-async.spec.js
@@ -25,4 +25,36 @@ test.describe('Theme export async flow', () => {
     await expect(downloadLink).toBeVisible();
     await expect(downloadLink).toHaveAttribute('href', /admin-ajax\.php/);
   });
+
+  test('resumes job status after page reload', async ({ admin, page, requestUtils }) => {
+    await requestUtils.activatePlugin('theme-export-jlg/theme-export-jlg.php');
+
+    await admin.visitAdminPage('admin.php', 'page=theme-export-jlg&tab=export');
+
+    const startButton = page.locator('[data-export-start]');
+    const feedback = page.locator('[data-export-feedback]');
+    const statusText = page.locator('[data-export-status-text]');
+    const downloadLink = page.locator('[data-export-download]');
+
+    await expect(startButton).toBeVisible();
+
+    const startRequest = page.waitForResponse((response) => {
+      return response.url().includes('admin-ajax.php')
+        && response.request().method() === 'POST'
+        && response.url().includes('tejlg_start_theme_export');
+    });
+
+    await startButton.click();
+
+    await startRequest;
+
+    await page.reload();
+
+    await expect(feedback).toBeVisible();
+
+    await expect(statusText).toContainText('Export terminé', { timeout: 15000 });
+
+    await expect(downloadLink).toBeVisible();
+    await expect(downloadLink).toHaveAttribute('href', /admin-ajax\.php/);
+  });
 });

--- a/tests/test-export-job-persistence.php
+++ b/tests/test-export-job-persistence.php
@@ -1,0 +1,106 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+
+/**
+ * @group export-theme
+ */
+class Test_Export_Job_Persistence extends WP_Ajax_UnitTestCase {
+
+    public function set_up() {
+        parent::set_up();
+        wp_set_current_user(0);
+    }
+
+    public function tear_down() {
+        wp_set_current_user(0);
+        parent::tear_down();
+    }
+
+    public function test_job_reference_persisted_and_cleared_after_status_lookup() {
+        $user_id = self::factory()->user->create([
+            'role' => 'administrator',
+        ]);
+
+        wp_set_current_user($user_id);
+
+        $job_id = TEJLG_Export::export_theme();
+
+        $this->assertNotWPError($job_id, 'The export job should be created successfully.');
+        $this->assertIsString($job_id, 'The job identifier should be a string.');
+        $this->assertSame($job_id, TEJLG_Export::get_user_job_reference($user_id), 'The job ID should be stored for the current user.');
+
+        $job = TEJLG_Export::get_job($job_id);
+
+        $this->assertIsArray($job, 'The job payload should be available.');
+
+        $job['status'] = 'completed';
+        $job['progress'] = 100;
+        $job['processed_items'] = isset($job['total_items']) ? (int) $job['total_items'] : 0;
+        TEJLG_Export::persist_job($job);
+
+        $_POST = [
+            'nonce'  => wp_create_nonce('tejlg_theme_export_status'),
+            'job_id' => $job_id,
+        ];
+        $_REQUEST = $_POST;
+
+        try {
+            $this->_handleAjax('tejlg_theme_export_status');
+        } catch (WPAjaxDieContinueException $exception) {
+            // Expected behaviour for AJAX handlers in tests.
+        }
+
+        $this->assertNotEmpty($this->_last_response, 'The AJAX handler should return a payload.');
+
+        $response = json_decode($this->_last_response, true);
+
+        $this->assertIsArray($response, 'The JSON response should decode to an array.');
+        $this->assertArrayHasKey('success', $response, 'The response should contain a success flag.');
+        $this->assertTrue($response['success'], 'The handler should return a success response.');
+        $this->assertSame('completed', $response['data']['job']['status'], 'The job status should be completed.');
+
+        $this->assertSame('', TEJLG_Export::get_user_job_reference($user_id), 'The stored job ID should be removed after completion.');
+
+        TEJLG_Export::delete_job($job_id);
+
+        $failed_job_id = TEJLG_Export::export_theme();
+
+        $this->assertNotWPError($failed_job_id, 'The second export job should also be created.');
+        $this->assertSame($failed_job_id, TEJLG_Export::get_user_job_reference($user_id), 'The new job ID should be stored.');
+
+        $failed_job = TEJLG_Export::get_job($failed_job_id);
+        $this->assertIsArray($failed_job, 'The failed job payload should be available.');
+
+        $failed_job['status'] = 'failed';
+        $failed_job['message'] = 'Failure during test.';
+        TEJLG_Export::persist_job($failed_job);
+
+        $_POST = [
+            'nonce'  => wp_create_nonce('tejlg_theme_export_status'),
+            'job_id' => $failed_job_id,
+        ];
+        $_REQUEST = $_POST;
+
+        try {
+            $this->_handleAjax('tejlg_theme_export_status');
+        } catch (WPAjaxDieContinueException $exception) {
+            // Expected behaviour for AJAX handlers in tests.
+        }
+
+        $this->assertNotEmpty($this->_last_response, 'The AJAX handler should return a payload for failed jobs.');
+
+        $failed_response = json_decode($this->_last_response, true);
+
+        $this->assertIsArray($failed_response, 'The failed job response should decode to an array.');
+        $this->assertArrayHasKey('success', $failed_response, 'The failed response should contain a success flag.');
+        $this->assertTrue($failed_response['success'], 'The handler should return a success response even when the job failed.');
+        $this->assertSame('failed', $failed_response['data']['job']['status'], 'The job status should be failed.');
+
+        $this->assertSame('', TEJLG_Export::get_user_job_reference($user_id), 'The stored job ID should be removed after a failure.');
+
+        TEJLG_Export::delete_job($failed_job_id);
+
+        wp_set_current_user(0);
+    }
+}

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -253,6 +253,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         if (startButton) {
                             startButton.disabled = false;
                         }
+                        currentJobId = null;
                     } else {
                         scheduleNextPoll(jobId);
                     }
@@ -269,6 +270,59 @@ document.addEventListener('DOMContentLoaded', function() {
                     handleError(message || strings.unknownError || '');
                 });
             };
+
+            const resumePersistedJob = function(snapshot) {
+                if (!snapshot || typeof snapshot !== 'object') {
+                    return;
+                }
+
+                const job = (typeof snapshot.job === 'object' && snapshot.job !== null)
+                    ? snapshot.job
+                    : null;
+
+                const persistedJobId = typeof snapshot.job_id === 'string' && snapshot.job_id.length
+                    ? snapshot.job_id
+                    : (job && typeof job.id === 'string')
+                        ? job.id
+                        : '';
+
+                if (!persistedJobId) {
+                    return;
+                }
+
+                currentJobId = persistedJobId;
+
+                if (job) {
+                    updateFeedback(job, { downloadUrl: '' });
+                }
+
+                const statusFromSnapshot = typeof snapshot.status === 'string' && snapshot.status.length
+                    ? snapshot.status
+                    : (job && typeof job.status === 'string')
+                        ? job.status
+                        : '';
+
+                const normalizedStatus = statusFromSnapshot.toLowerCase();
+
+                const shouldFetch = ['queued', 'processing', 'completed', 'failed'].indexOf(normalizedStatus) !== -1;
+
+                if (!shouldFetch) {
+                    return;
+                }
+
+                if (normalizedStatus === 'queued' || normalizedStatus === 'processing') {
+                    setSpinner(true);
+                    if (startButton) {
+                        startButton.disabled = true;
+                    }
+                }
+
+                fetchStatus(persistedJobId);
+            };
+
+            if (exportAsync.previousJob) {
+                resumePersistedJob(exportAsync.previousJob);
+            }
 
             if (startButton) {
                 startButton.addEventListener('click', function() {

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -88,6 +88,7 @@ class TEJLG_Admin {
                         'unknownError'    => esc_html__('Une erreur inattendue est survenue.', 'theme-export-jlg'),
                         'statusLabel'     => esc_html__('Statut de la tâche : %1$s', 'theme-export-jlg'),
                     ],
+                    'previousJob' => TEJLG_Export::get_current_user_job_snapshot(),
                 ],
             ]
         );


### PR DESCRIPTION
## Summary
- persist the most recent export job id in user meta and clear it once status polling reports a finished job
- expose the stored job through localized script data so the admin UI can immediately resume polling after a reload
- cover the new persistence behaviour with a PHPUnit ajax test and extend the Playwright suite with a reload scenario

## Testing
- npm run test:php *(fails: phpunit binary not available in the environment)*
- npm run test:e2e *(fails: WordPress test REST API at http://localhost:8889 refused connections)*

------
https://chatgpt.com/codex/tasks/task_e_68dc354f9bac832e990cb3dce4adccb3