### PR TITLE
Improve admin cards responsive layout

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -1,9 +1,15 @@
 /* Style des cartes pour les onglets */
 .tejlg-cards-container {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 420px));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 20px;
     margin-top: 1em;
+}
+
+@media (max-width: 600px) {
+    .tejlg-cards-container {
+        grid-template-columns: 1fr;
+    }
 }
 
 .tejlg-card {


### PR DESCRIPTION
## Summary
- make the admin cards grid responsive by using a fluid repeat/auto-fit template
- add a mobile breakpoint to force a single column on narrow viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0e8aad84832ebd58296df54d3413