### PR TITLE
Improve accessibility of pattern code preview toggles

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -426,19 +426,22 @@ document.addEventListener('DOMContentLoaded', function() {
             if (e.target.classList.contains('toggle-code-view')) {
                 const button = e.target;
                 const patternItem = button.closest('.pattern-item');
-                const codeView = patternItem.querySelector('.pattern-code-view');
+                const codeView = patternItem ? patternItem.querySelector('.pattern-code-view') : null;
 
                 if (codeView) {
-                    const isVisible = codeView.style.display !== 'none';
-                    if (isVisible) {
-                        codeView.style.display = 'none';
-                        if (showBlockCodeText) {
-                            button.textContent = showBlockCodeText;
-                        }
-                    } else {
-                        codeView.style.display = 'block';
+                    const isHidden = codeView.hasAttribute('hidden');
+
+                    if (isHidden) {
+                        codeView.hidden = false;
+                        button.setAttribute('aria-expanded', 'true');
                         if (hideBlockCodeText) {
                             button.textContent = hideBlockCodeText;
+                        }
+                    } else {
+                        codeView.hidden = true;
+                        button.setAttribute('aria-expanded', 'false');
+                        if (showBlockCodeText) {
+                            button.textContent = showBlockCodeText;
                         }
                     }
                 }

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -1210,10 +1210,21 @@ class TEJLG_Admin {
                         </div>
 
                         <div class="pattern-controls">
-                            <button type="button" class="button-link toggle-code-view"><?php esc_html_e('Afficher le code du bloc', 'theme-export-jlg'); ?></button>
+                            <button
+                                type="button"
+                                class="button-link toggle-code-view"
+                                aria-controls="pattern-code-view-<?php echo esc_attr($pattern_data['index']); ?>"
+                                aria-expanded="false"
+                            >
+                                <?php esc_html_e('Afficher le code du bloc', 'theme-export-jlg'); ?>
+                            </button>
                         </div>
 
-                        <div class="pattern-code-view" style="display: none;">
+                        <div
+                            class="pattern-code-view"
+                            id="pattern-code-view-<?php echo esc_attr($pattern_data['index']); ?>"
+                            hidden
+                        >
                             <pre><code><?php echo esc_html($pattern_data['content']); ?></code></pre>
 
                             <details class="css-accordion">


### PR DESCRIPTION
## Summary
- assign unique IDs to each pattern code section and link toggle buttons with ARIA attributes
- default code previews to hidden using the `hidden` attribute for better semantics
- update admin preview script to toggle the hidden state and aria-expanded flag instead of inline styles

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd0e8dd0ec832e9e68104a93e43ad3