### PR TITLE
Improve accessibility of export progress feedback

### DIFF
--- a/tests/test-admin-export-tab.php
+++ b/tests/test-admin-export-tab.php
@@ -53,4 +53,27 @@ class Test_Admin_Export_Tab extends WP_UnitTestCase {
             'Pattern selection page should not be rendered when action is invalid.'
         );
     }
+
+    public function test_export_progress_has_accessible_label() {
+        $admin = new TEJLG_Admin();
+
+        $reflection = new ReflectionMethod(TEJLG_Admin::class, 'render_export_tab');
+        $reflection->setAccessible(true);
+
+        ob_start();
+        $reflection->invoke($admin);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString(
+            'id="tejlg-theme-export-status"',
+            $output,
+            'The status element should expose an id for accessibility.'
+        );
+
+        $this->assertStringContainsString(
+            'aria-labelledby="tejlg-theme-export-status"',
+            $output,
+            'The progress bar should reference the status text for screen readers.'
+        );
+    }
 }

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -647,8 +647,18 @@ class TEJLG_Admin {
                         <span class="spinner" aria-hidden="true" data-export-spinner></span>
                     </p>
                     <div class="tejlg-theme-export-feedback notice notice-info" data-export-feedback hidden>
-                        <p class="tejlg-theme-export-status" role="status" data-export-status-text><?php esc_html_e('En attente de démarrage…', 'theme-export-jlg'); ?></p>
-                        <progress value="0" max="100" data-export-progress-bar></progress>
+                        <p
+                            id="tejlg-theme-export-status"
+                            class="tejlg-theme-export-status"
+                            role="status"
+                            data-export-status-text
+                        ><?php esc_html_e('En attente de démarrage…', 'theme-export-jlg'); ?></p>
+                        <progress
+                            value="0"
+                            max="100"
+                            aria-labelledby="tejlg-theme-export-status"
+                            data-export-progress-bar
+                        ></progress>
                         <p class="description" data-export-message></p>
                         <p><a href="#" class="button button-secondary" data-export-download hidden target="_blank" rel="noopener"><?php esc_html_e("Télécharger l'archive ZIP", 'theme-export-jlg'); ?></a></p>
                     </div>


### PR DESCRIPTION
## Summary
- assign an id to the export status live region and connect the progress bar with aria-labelledby
- add PHPUnit coverage to confirm the accessible relationship is rendered

## Testing
- npm run test:php *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0e8faa64832e9d36612bd733ab9e