### PR TITLE
Add user-controlled performance metrics activation

### DIFF
--- a/tests/e2e/performance-metrics.spec.js
+++ b/tests/e2e/performance-metrics.spec.js
@@ -1,22 +1,37 @@
 const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
 
 test.describe('Performance metrics badge', () => {
-  test('updates FPS and latency metrics with accessible output', async ({ admin, page, requestUtils }) => {
+  test('requires manual activation before updating metrics', async ({ admin, page, requestUtils }) => {
     await requestUtils.activatePlugin('theme-export-jlg/theme-export-jlg.php');
 
     await admin.visitAdminPage('admin.php', 'page=theme-export-jlg&tab=debug');
 
     const fpsMetric = page.locator('#tejlg-metric-fps');
     const latencyMetric = page.locator('#tejlg-metric-latency');
+    const toggleButton = page.getByRole('button', { name: /Démarrer la mesure/i });
+    const status = page.locator('[data-metrics-status]');
 
     await expect(fpsMetric).toHaveAttribute('aria-live', /polite|assertive/i);
     await expect(latencyMetric).toHaveAttribute('aria-live', /polite|assertive/i);
+
+    await expect(toggleButton).toHaveAttribute('aria-pressed', 'false');
+    await expect(status).toContainText('Appuyez pour mesurer');
+
+    const initialFps = ((await fpsMetric.textContent()) || '').trim();
+    const initialLatency = ((await latencyMetric.textContent()) || '').trim();
+    await page.waitForTimeout(2000);
+    await expect(fpsMetric).toHaveText(initialFps);
+    await expect(latencyMetric).toHaveText(initialLatency);
+
+    await toggleButton.click();
+    await expect(toggleButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(status).toContainText(/Mesure en cours/i);
 
     const fpsText = await expect.poll(
       async () => (await fpsMetric.textContent())?.trim() || '',
       {
         timeout: 10000,
-        message: 'Expected FPS metric to display a numeric value',
+        message: 'Expected FPS metric to display a numeric value after activation',
       }
     );
     expect(fpsText).toMatch(/\d/);
@@ -25,9 +40,13 @@ test.describe('Performance metrics badge', () => {
       async () => (await latencyMetric.textContent())?.trim() || '',
       {
         timeout: 10000,
-        message: 'Expected latency metric to display a numeric value',
+        message: 'Expected latency metric to display a numeric value after activation',
       }
     );
     expect(latencyText).toMatch(/\d/);
+
+    await toggleButton.click();
+    await expect(toggleButton).toHaveAttribute('aria-pressed', 'false');
+    await expect(status).toContainText(/Appuyez pour mesurer/i);
   });
 });

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -64,6 +64,13 @@ class TEJLG_Admin {
                     'ariaLivePolite'   => 'polite',
                     'ariaAtomic'       => 'true',
                     'latencyPrecision' => 1,
+                    'startLabel'       => esc_html__('Démarrer la mesure', 'theme-export-jlg'),
+                    'stopLabel'        => esc_html__('Arrêter la mesure', 'theme-export-jlg'),
+                    'tapToMeasure'     => esc_html__('Appuyez pour mesurer', 'theme-export-jlg'),
+                    'runningLabel'     => esc_html__('Mesure en cours…', 'theme-export-jlg'),
+                    'stoppedLabel'     => esc_html__('Mesure arrêtée.', 'theme-export-jlg'),
+                    'autoStopNotice'   => esc_html__('Arrêt automatique après une minute.', 'theme-export-jlg'),
+                    'autoStopSeconds'  => 60,
                 ],
                 'exportAsync' => [
                     'ajaxUrl' => admin_url('admin-ajax.php'),
@@ -956,6 +963,27 @@ class TEJLG_Admin {
                 <?php esc_html_e('La barre de menu des métriques utilisera cette taille pour aligner les icônes.', 'theme-export-jlg'); ?>
             </p>
         </form>
+        <div class="metrics-controls">
+            <button
+                type="button"
+                class="button button-primary metrics-toggle"
+                data-metrics-toggle
+                aria-pressed="false"
+            >
+                <?php esc_html_e('Démarrer la mesure', 'theme-export-jlg'); ?>
+            </button>
+            <p
+                class="metrics-status"
+                id="tejlg-metrics-status"
+                data-metrics-status
+                role="status"
+            >
+                <?php esc_html_e('Appuyez pour mesurer', 'theme-export-jlg'); ?>
+            </p>
+        </div>
+        <p class="description metrics-help-text">
+            <?php esc_html_e('La collecte reste inactive tant que vous ne la lancez pas afin d’économiser les ressources. Une fois démarrée, elle s’arrêtera automatiquement après une minute.', 'theme-export-jlg'); ?>
+        </p>
         <div class="metrics-badge" role="group" aria-label="<?php esc_attr_e('Indicateurs de performance', 'theme-export-jlg'); ?>">
             <div class="metric metric-fps">
                 <span class="metric-icon metric-icon-fps dashicons dashicons-dashboard" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- add a manual toggle button, status indicator, and help text to the debug metrics badge
- gate the performance sampling loop behind explicit user activation, support stopping/auto-timeout, and localize the new labels
- extend the Playwright test to verify metrics stay idle until the measurement is started

## Testing
- `npm run test:e2e -- performance-metrics` *(fails: unable to reach local WordPress REST API in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd69070640832ea5343256f80ef3e0