### PR TITLE
Improve debug accordion accessibility

### DIFF
--- a/tests/e2e/debug-accordion.spec.js
+++ b/tests/e2e/debug-accordion.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+
+test.describe('Debug accordion accessibility', () => {
+  test('allows keyboard navigation and aria-expanded toggling', async ({ admin, page, requestUtils }) => {
+    await requestUtils.activatePlugin('theme-export-jlg/theme-export-jlg.php');
+
+    await admin.visitAdminPage('admin.php', 'page=theme-export-jlg&tab=debug');
+
+    const systemButton = page.getByRole('button', { name: 'Informations Système & WordPress' });
+    const systemContent = page.locator('#tejlg-debug-section-system');
+    const patternsButton = page.getByRole('button', { name: 'Compositions personnalisées enregistrées' });
+    const patternsContent = page.locator('#tejlg-debug-section-patterns');
+
+    await expect(systemButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(systemContent).toBeHidden();
+
+    await systemButton.focus();
+    await expect(systemButton).toBeFocused();
+
+    await page.keyboard.press('Enter');
+    await expect(systemButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(systemContent).toBeVisible();
+
+    await page.keyboard.press('Space');
+    await expect(systemButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(systemContent).toBeHidden();
+
+    await patternsButton.focus();
+    await expect(patternsButton).toBeFocused();
+
+    await page.keyboard.press('Space');
+    await expect(patternsButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(patternsContent).toBeVisible();
+  });
+});

--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -109,28 +109,40 @@
 
 /* Style pour l'accordéon de débogage */
 #debug-accordion .accordion-section-title {
-    border-bottom: 1px solid #ccc;
-    padding: 15px;
-    cursor: pointer;
-    font-size: 1.2em;
-    background: #f6f7f7;
     margin: 0;
 }
 
-#debug-accordion .accordion-section-title:hover {
-    background: #e9e9e9;
+#debug-accordion .accordion-section-trigger {
+    width: 100%;
+    padding: 15px;
+    font-size: 1.2em;
+    text-align: left;
+    background-color: #f6f7f7;
+    border: 1px solid #ccc;
+    border-radius: 0;
+    color: #1d2327;
+    cursor: pointer;
+}
+
+#debug-accordion .accordion-section-trigger:hover,
+#debug-accordion .accordion-section.open .accordion-section-trigger {
+    background-color: #e9e9e9;
+}
+
+#debug-accordion .accordion-section-trigger:focus-visible {
+    outline: 3px solid #2271b1;
+    outline-offset: 2px;
 }
 
 #debug-accordion .accordion-section-content {
     padding: 15px;
-    display: none;
     border: 1px solid #ccc;
     border-top: 0;
     background: #fff;
 }
 
-#debug-accordion .accordion-section.open .accordion-section-content {
-    display: block;
+#debug-accordion .accordion-section-content[hidden] {
+    display: none;
 }
 #debug-accordion ul {
     list-style: disc;

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -408,12 +408,41 @@ document.addEventListener('DOMContentLoaded', function() {
     // Gérer l'accordéon sur la page de débogage
     const accordionContainer = document.getElementById('debug-accordion');
     if (accordionContainer) {
-        const accordionTitles = accordionContainer.querySelectorAll('.accordion-section-title');
-        accordionTitles.forEach(function(title) {
-            title.addEventListener('click', function() {
-                const parentSection = this.closest('.accordion-section');
-                if (parentSection) {
-                    parentSection.classList.toggle('open');
+        const accordionSections = accordionContainer.querySelectorAll('.accordion-section');
+        accordionSections.forEach(function(section) {
+            const trigger = section.querySelector('.accordion-section-trigger');
+            const content = section.querySelector('.accordion-section-content');
+
+            if (!trigger || !content) {
+                return;
+            }
+
+            const syncState = function(isOpen) {
+                trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+                content.hidden = !isOpen;
+            };
+
+            const toggleSection = function() {
+                const isOpen = section.classList.toggle('open');
+                syncState(isOpen);
+            };
+
+            syncState(section.classList.contains('open') || trigger.getAttribute('aria-expanded') === 'true');
+
+            trigger.addEventListener('click', function() {
+                if (trigger.dataset.skipClick === 'true') {
+                    trigger.dataset.skipClick = 'false';
+                    return;
+                }
+
+                toggleSection();
+            });
+
+            trigger.addEventListener('keydown', function(event) {
+                if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+                    event.preventDefault();
+                    trigger.dataset.skipClick = 'true';
+                    toggleSection();
                 }
             });
         });

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -972,8 +972,23 @@ class TEJLG_Admin {
         <p><?php esc_html_e('Ces informations peuvent vous aider à diagnostiquer des problèmes liés à votre configuration ou à vos données.', 'theme-export-jlg'); ?></p>
         <div id="debug-accordion">
             <div class="accordion-section">
-                <h3 class="accordion-section-title"><?php esc_html_e('Informations Système & WordPress', 'theme-export-jlg'); ?></h3>
-                <div class="accordion-section-content">
+                <h3 class="accordion-section-title">
+                    <button
+                        type="button"
+                        class="accordion-section-trigger"
+                        id="tejlg-debug-section-system-trigger"
+                        aria-expanded="false"
+                        aria-controls="tejlg-debug-section-system"
+                    >
+                        <?php esc_html_e('Informations Système & WordPress', 'theme-export-jlg'); ?>
+                    </button>
+                </h3>
+                <div
+                    class="accordion-section-content"
+                    id="tejlg-debug-section-system"
+                    aria-labelledby="tejlg-debug-section-system-trigger"
+                    hidden
+                >
                     <table class="widefat striped">
                         <tbody>
                             <tr>
@@ -1009,8 +1024,23 @@ class TEJLG_Admin {
                 </div>
             </div>
             <div class="accordion-section">
-                <h3 class="accordion-section-title"><?php esc_html_e('Compositions personnalisées enregistrées', 'theme-export-jlg'); ?></h3>
-                <div class="accordion-section-content">
+                <h3 class="accordion-section-title">
+                    <button
+                        type="button"
+                        class="accordion-section-trigger"
+                        id="tejlg-debug-section-patterns-trigger"
+                        aria-expanded="false"
+                        aria-controls="tejlg-debug-section-patterns"
+                    >
+                        <?php esc_html_e('Compositions personnalisées enregistrées', 'theme-export-jlg'); ?>
+                    </button>
+                </h3>
+                <div
+                    class="accordion-section-content"
+                    id="tejlg-debug-section-patterns"
+                    aria-labelledby="tejlg-debug-section-patterns-trigger"
+                    hidden
+                >
                     <?php
                     if (class_exists('WP_Block_Patterns_Registry')) {
                         $patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();


### PR DESCRIPTION
## Summary
- replace the debug accordion headings with labelled buttons that expose aria attributes and ids
- update the admin script to toggle aria-expanded/hidden states and support keyboard interaction while keeping section classes in sync
- refresh the accordion styles for focus visibility and add a Playwright test covering keyboard toggling on the debug tab

## Testing
- `npm run test:e2e -- tests/e2e/debug-accordion.spec.js` *(fails: Failed to setup REST API)*

------
https://chatgpt.com/codex/tasks/task_e_68dd69031160832ea5d3cbf7d453d9a5