### PR TITLE
Add live pattern selection status updates

### DIFF
--- a/tests/e2e/pattern-export-select-all.spec.js
+++ b/tests/e2e/pattern-export-select-all.spec.js
@@ -26,6 +26,7 @@ test.describe('Pattern export selection screen', () => {
     const selectAll = page.locator('#select-all-export-patterns');
     const searchInput = page.locator('#pattern-search');
     const visibleItems = page.locator('.pattern-selection-item:not(.is-hidden)');
+    const statusLiveRegion = page.locator('#pattern-selection-status');
     const alphaCheckbox = page.locator('.pattern-selection-item', { hasText: 'Alpha Pattern' }).locator('input[type="checkbox"]');
     const betaCheckbox = page.locator('.pattern-selection-item', { hasText: 'Beta Pattern' }).locator('input[type="checkbox"]');
     const gammaCheckbox = page.locator('.pattern-selection-item', { hasText: 'Gamma Pattern' }).locator('input[type="checkbox"]');
@@ -33,6 +34,9 @@ test.describe('Pattern export selection screen', () => {
     await expect(visibleItems).toHaveCount(patterns.length);
     await expect(selectAll).not.toBeChecked();
     await expect(selectAll).toHaveJSProperty('indeterminate', false);
+    await expect(statusLiveRegion).toHaveText('3 compositions visibles.');
+    await expect(statusLiveRegion).toHaveAttribute('aria-live', 'polite');
+    await expect(statusLiveRegion).toHaveAttribute('aria-busy', 'false');
 
     await alphaCheckbox.check();
 
@@ -46,6 +50,8 @@ test.describe('Pattern export selection screen', () => {
     await expect(page.locator('.pattern-selection-item.is-hidden')).toHaveCount(patterns.length - 1);
     await expect(selectAll).not.toBeChecked();
     await expect(selectAll).toHaveJSProperty('indeterminate', false);
+    await expect(statusLiveRegion).toHaveText('1 composition visible.');
+    await expect(statusLiveRegion).toHaveAttribute('aria-busy', 'false');
 
     await selectAll.check();
 
@@ -59,6 +65,8 @@ test.describe('Pattern export selection screen', () => {
     await expect(page.locator('.pattern-selection-item.is-hidden')).toHaveCount(0);
     await expect(selectAll).not.toBeChecked();
     await expect(selectAll).toHaveJSProperty('indeterminate', true);
+    await expect(statusLiveRegion).toHaveText('3 compositions visibles.');
+    await expect(statusLiveRegion).toHaveAttribute('aria-busy', 'false');
 
     await selectAll.check();
 
@@ -75,6 +83,8 @@ test.describe('Pattern export selection screen', () => {
     await expect(page.locator('.pattern-selection-item.is-hidden')).toHaveCount(patterns.length - 1);
     await expect(selectAll).toBeChecked();
     await expect(selectAll).toHaveJSProperty('indeterminate', false);
+    await expect(statusLiveRegion).toHaveText('1 composition visible.');
+    await expect(statusLiveRegion).toHaveAttribute('aria-busy', 'false');
 
     await selectAll.uncheck();
 
@@ -93,6 +103,8 @@ test.describe('Pattern export selection screen', () => {
     await expect(gammaCheckbox).not.toBeChecked();
     await expect(selectAll).not.toBeChecked();
     await expect(selectAll).toHaveJSProperty('indeterminate', true);
+    await expect(statusLiveRegion).toHaveText('3 compositions visibles.');
+    await expect(statusLiveRegion).toHaveAttribute('aria-busy', 'false');
   });
 
   test('displays fallback title for untitled patterns and allows searching with it', async ({ admin, page, requestUtils }) => {

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -500,6 +500,25 @@ document.addEventListener('DOMContentLoaded', function() {
     const patternItems = patternList ? Array.from(patternList.querySelectorAll('.pattern-selection-item')) : [];
     const selectAllExportCheckbox = document.getElementById('select-all-export-patterns');
     const patternSearchInput = document.getElementById('pattern-search');
+    const patternSelectionStatus = document.getElementById('pattern-selection-status');
+    const patternSelectionStatusStrings = (typeof localization.patternSelectionStatus === 'object' && localization.patternSelectionStatus !== null)
+        ? localization.patternSelectionStatus
+        : {};
+    const patternSelectionNumberFormatter = (function() {
+        const locale = typeof patternSelectionStatusStrings.numberLocale === 'string' && patternSelectionStatusStrings.numberLocale
+            ? patternSelectionStatusStrings.numberLocale
+            : undefined;
+
+        if (typeof Intl === 'object' && typeof Intl.NumberFormat === 'function') {
+            try {
+                return new Intl.NumberFormat(locale);
+            } catch (error) {
+                return new Intl.NumberFormat();
+            }
+        }
+
+        return null;
+    })();
 
     function getVisiblePatternItems() {
         return patternItems.filter(function(item) {
@@ -507,12 +526,62 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    function updateSelectAllExportCheckbox() {
-        if (!selectAllExportCheckbox) {
+    function setPatternSelectionBusy(isBusy) {
+        if (!patternSelectionStatus) {
             return;
         }
 
+        patternSelectionStatus.setAttribute('aria-busy', isBusy ? 'true' : 'false');
+    }
+
+    function formatPatternSelectionCount(count) {
+        if (patternSelectionNumberFormatter) {
+            return patternSelectionNumberFormatter.format(count);
+        }
+
+        return String(count);
+    }
+
+    function updatePatternSelectionStatus() {
+        if (!patternSelectionStatus) {
+            return;
+        }
+
+        const visibleCount = getVisiblePatternItems().length;
+        let message = '';
+
+        if (visibleCount === 0) {
+            message = typeof patternSelectionStatusStrings.empty === 'string'
+                ? patternSelectionStatusStrings.empty
+                : '';
+        } else if (visibleCount === 1) {
+            const template = typeof patternSelectionStatusStrings.countSingular === 'string'
+                ? patternSelectionStatusStrings.countSingular
+                : (typeof patternSelectionStatusStrings.countPlural === 'string'
+                    ? patternSelectionStatusStrings.countPlural
+                    : '%s');
+            message = template.replace('%s', formatPatternSelectionCount(visibleCount));
+        } else {
+            const template = typeof patternSelectionStatusStrings.countPlural === 'string'
+                ? patternSelectionStatusStrings.countPlural
+                : (typeof patternSelectionStatusStrings.countSingular === 'string'
+                    ? patternSelectionStatusStrings.countSingular
+                    : '%s');
+            message = template.replace('%s', formatPatternSelectionCount(visibleCount));
+        }
+
+        patternSelectionStatus.textContent = message;
+        setPatternSelectionBusy(false);
+    }
+
+    function updateSelectAllExportCheckbox() {
         const visibleItems = getVisiblePatternItems();
+
+        if (!selectAllExportCheckbox) {
+            updatePatternSelectionStatus();
+            return;
+        }
+
         const visibleCheckboxes = visibleItems
             .map(function(item) {
                 return item.querySelector('input[type="checkbox"]');
@@ -544,14 +613,18 @@ document.addEventListener('DOMContentLoaded', function() {
             selectAllExportCheckbox.checked = false;
             selectAllExportCheckbox.indeterminate = true;
         }
+
+        updatePatternSelectionStatus();
     }
 
     function filterPatternItems(query) {
         if (!patternItems.length) {
+            setPatternSelectionBusy(true);
             updateSelectAllExportCheckbox();
             return;
         }
 
+        setPatternSelectionBusy(true);
         const normalizedQuery = query.trim().toLowerCase();
 
         patternItems.forEach(function(item) {
@@ -566,6 +639,10 @@ document.addEventListener('DOMContentLoaded', function() {
         });
 
         updateSelectAllExportCheckbox();
+    }
+
+    if (patternSelectionStatus) {
+        setPatternSelectionBusy(false);
     }
 
     if (selectAllExportCheckbox) {

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -82,6 +82,12 @@ class TEJLG_Admin {
                     'ariaAtomic'       => 'true',
                     'latencyPrecision' => 1,
                 ],
+                'patternSelectionStatus' => [
+                    'numberLocale'   => get_user_locale(),
+                    'empty'          => esc_html__('Aucune composition visible.', 'theme-export-jlg'),
+                    'countSingular'  => esc_html__('%s composition visible.', 'theme-export-jlg'),
+                    'countPlural'    => esc_html__('%s compositions visibles.', 'theme-export-jlg'),
+                ],
                 'exportAsync' => [
                     'ajaxUrl' => admin_url('admin-ajax.php'),
                     'actions' => [

--- a/theme-export-jlg/templates/admin/export-pattern-selection.php
+++ b/theme-export-jlg/templates/admin/export-pattern-selection.php
@@ -27,6 +27,7 @@ $back_url = add_query_arg([
                 <label class="screen-reader-text" for="pattern-search"><?php esc_html_e('Rechercher une composition', 'theme-export-jlg'); ?></label>
                 <input type="search" id="pattern-search" placeholder="<?php echo esc_attr__('Rechercher…', 'theme-export-jlg'); ?>" aria-controls="pattern-selection-items">
             </p>
+            <p id="pattern-selection-status" aria-live="polite" class="screen-reader-text"></p>
             <ul class="pattern-selection-items" id="pattern-selection-items" aria-live="polite" data-searchable="true">
                 <?php
                 $pattern_counter = $per_page > 0 ? (($current_page - 1) * $per_page) : 0;


### PR DESCRIPTION
## Summary
- add a screen-reader live region next to the pattern export search field
- localize strings and update the admin script to announce visible counts and aria-busy state while filtering
- extend the Playwright coverage to check the live region text during search interactions

## Testing
- `npx playwright test tests/e2e/pattern-export-select-all.spec.js` *(fails: Failed to setup REST API)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9147f16c832eb0e997f46ac83e74