### PR TITLE
Adjust admin preview iframe sizing behavior

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -102,7 +102,7 @@
 
 .pattern-preview-iframe {
     width: 100%;
-    height: 250px;
+    min-height: 250px;
     border: 1px dashed #ccc;
     background: #fff;
 }


### PR DESCRIPTION
## Summary
- replace the fixed admin preview iframe height with a CSS min-height
- dynamically size iframe previews after loading HTML from blobs, srcdoc, or fallback writes
- observe preview content for post-load changes and clean up observers when iframes are removed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de669e9878832e8cf926f70da40a0a