### PR TITLE
Refactor import preview global CSS section

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -425,12 +425,26 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Gérer l'affichage/masquage du code des compositions
     const previewList = document.getElementById('patterns-preview-list');
+    const globalCssDetails = document.getElementById('tejlg-global-css');
     if (previewList) {
         previewList.addEventListener('click', function(e) {
-            if (e.target.classList.contains('toggle-code-view')) {
-                const button = e.target;
-                const patternItem = button.closest('.pattern-item');
-                const codeView = patternItem ? patternItem.querySelector('.pattern-code-view') : null;
+            const button = e.target.closest('.toggle-code-view');
+            if (button) {
+                if (!button.dataset.showLabel) {
+                    button.dataset.showLabel = button.textContent.trim();
+                }
+
+                const controlledId = button.getAttribute('aria-controls');
+                let codeView = null;
+
+                if (controlledId) {
+                    codeView = document.getElementById(controlledId);
+                }
+
+                if (!codeView) {
+                    const patternItem = button.closest('.pattern-item');
+                    codeView = patternItem ? patternItem.querySelector('.pattern-code-view') : null;
+                }
 
                 if (codeView) {
                     const isHidden = codeView.hasAttribute('hidden');
@@ -438,16 +452,72 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (isHidden) {
                         codeView.hidden = false;
                         button.setAttribute('aria-expanded', 'true');
-                        if (hideBlockCodeText) {
-                            button.textContent = hideBlockCodeText;
+                        const hideLabel = hideBlockCodeText || button.dataset.hideLabel;
+                        if (hideLabel) {
+                            button.textContent = hideLabel;
+                            button.dataset.hideLabel = hideLabel;
                         }
                     } else {
                         codeView.hidden = true;
                         button.setAttribute('aria-expanded', 'false');
-                        if (showBlockCodeText) {
-                            button.textContent = showBlockCodeText;
+                        const showLabel = showBlockCodeText || button.dataset.showLabel;
+                        if (showLabel) {
+                            button.textContent = showLabel;
                         }
                     }
+                }
+
+                return;
+            }
+
+            const cssTrigger = e.target.closest('.global-css-trigger');
+            if (cssTrigger) {
+                e.preventDefault();
+
+                let selector = cssTrigger.getAttribute('data-target');
+                if (!selector) {
+                    const href = cssTrigger.getAttribute('href');
+                    if (href && href.charAt(0) === '#') {
+                        selector = href;
+                    }
+                }
+
+                let targetDetails = null;
+
+                if (selector) {
+                    try {
+                        targetDetails = document.querySelector(selector);
+                    } catch (error) {
+                        targetDetails = null;
+                    }
+                }
+
+                if (!targetDetails) {
+                    targetDetails = globalCssDetails;
+                }
+
+                if (!targetDetails) {
+                    return;
+                }
+
+                if (targetDetails.tagName === 'DETAILS') {
+                    targetDetails.open = true;
+                    const summary = targetDetails.querySelector('summary');
+                    if (summary && typeof summary.focus === 'function') {
+                        summary.focus();
+                    } else if (typeof targetDetails.focus === 'function') {
+                        targetDetails.setAttribute('tabindex', '-1');
+                        targetDetails.focus();
+                        targetDetails.removeAttribute('tabindex');
+                    }
+                }
+
+                if (targetDetails.id) {
+                    window.location.hash = targetDetails.id;
+                }
+
+                if (typeof targetDetails.scrollIntoView === 'function') {
+                    targetDetails.scrollIntoView({ behavior: 'smooth', block: 'start' });
                 }
             }
         });

--- a/theme-export-jlg/templates/admin/import-preview.php
+++ b/theme-export-jlg/templates/admin/import-preview.php
@@ -6,10 +6,11 @@
 /** @var array  $warnings */
 /** @var string $global_styles */
 
-$import_tab_url = add_query_arg([
+$import_tab_url    = add_query_arg([
     'page' => $page_slug,
     'tab'  => 'import',
 ], admin_url('admin.php'));
+$has_global_styles = '' !== trim($global_styles);
 ?>
 <h2><?php esc_html_e('Étape 2 : Choisir les compositions à importer', 'theme-export-jlg'); ?></h2>
 <p><?php esc_html_e('Cochez les compositions à importer. Vous pouvez prévisualiser le rendu et inspecter le code du bloc (le code CSS du thème est masqué par défaut).', 'theme-export-jlg'); ?></p>
@@ -55,15 +56,29 @@ $import_tab_url = add_query_arg([
                     hidden
                 >
                     <pre><code><?php echo esc_html($pattern_data['content']); ?></code></pre>
-
-                    <details class="css-accordion">
-                        <summary><?php esc_html_e('Afficher le CSS global du thème', 'theme-export-jlg'); ?></summary>
-                        <pre><code><?php echo esc_html($global_styles); ?></code></pre>
-                    </details>
+                    <?php if ($has_global_styles): ?>
+                        <p class="pattern-global-css-link">
+                            <button
+                                type="button"
+                                class="button-link global-css-trigger"
+                                data-target="#tejlg-global-css"
+                            >
+                                <?php esc_html_e('Afficher le CSS global du thème', 'theme-export-jlg'); ?>
+                            </button>
+                        </p>
+                    <?php endif; ?>
                 </div>
 
             </div>
         <?php endforeach; ?>
+        <?php if ($has_global_styles): ?>
+            <div class="global-css-container">
+                <details class="css-accordion" id="tejlg-global-css">
+                    <summary><?php esc_html_e('Afficher le CSS global du thème', 'theme-export-jlg'); ?></summary>
+                    <pre><code><?php echo esc_html($global_styles); ?></code></pre>
+                </details>
+            </div>
+        <?php endif; ?>
         <?php if (!empty($encoding_failures)): ?>
             <div class="notice notice-warning">
                 <?php foreach ($encoding_failures as $failure_message): ?>


### PR DESCRIPTION
## Summary
- render the global CSS accordion once outside the pattern loop and reference it from each preview card
- update the admin preview script to read aria-controls, manage button labels, and direct shared CSS triggers to the single accordion

## Testing
- php -l theme-export-jlg/templates/admin/import-preview.php
- npm run test:e2e *(fails: WordPress test environment REST API unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68de8ac50c60832eb27b3b9db78e84ae