### PR TITLE
Adjust pattern selection layout on mobile

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -230,6 +230,18 @@
     background: #fdfdfd;
 }
 
+@media (max-width: 782px) {
+    .pattern-selection-list {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    #pattern-selection-items {
+        max-height: none;
+        overflow-y: visible;
+    }
+}
+
 .pattern-selection-list li {
     padding: 0.25rem 0;
     list-style: none;


### PR DESCRIPTION
## Summary
- remove the fixed height and internal scroll from the pattern selection list on mobile viewports so the page scrolls naturally
- reduce horizontal padding of the pattern selection panel to better fit small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68debe28f8b8832e8b99262254a853ad