### PR TITLE
Enhance dynamic block placeholder accessibility

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -108,6 +108,37 @@
     background: #fff;
 }
 
+/* Placeholder pour les blocs dynamiques non rendus */
+.tejlg-block-placeholder {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin: 12px 0;
+    padding: 16px 18px;
+    border: 2px dashed #2b4a6f;
+    border-radius: 8px;
+    background-color: #f2f5ff;
+    color: #0f213b;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.tejlg-block-placeholder:focus-visible {
+    outline: 3px solid #1c64f2;
+    outline-offset: 2px;
+}
+
+.tejlg-block-placeholder__icon {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    color: inherit;
+}
+
+.tejlg-block-placeholder__message {
+    margin: 0;
+}
+
 /* Style pour l'accordéon de débogage */
 #debug-accordion .accordion-section-title {
     border-bottom: 1px solid #ccc;

--- a/theme-export-jlg/includes/class-tejlg-admin-import-page.php
+++ b/theme-export-jlg/includes/class-tejlg-admin-import-page.php
@@ -574,6 +574,9 @@ class TEJLG_Admin_Import_Page extends TEJLG_Admin_Page {
             esc_html($block_label)
         );
 
-        return '<div class="tejlg-block-placeholder"><p>' . $placeholder_text . '</p></div>';
+        $icon_svg = '<svg class="tejlg-block-placeholder__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false" role="img">'
+            . '<path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10.011 10.011 0 0 0 12 2Zm0 15.25a1.25 1.25 0 1 1 1.25-1.25A1.251 1.251 0 0 1 12 17.25Zm1.5-5.75a1.5 1.5 0 0 1-3 0V7.75a1.5 1.5 0 0 1 3 0Z"/></svg>';
+
+        return '<div class="tejlg-block-placeholder" role="note">' . $icon_svg . '<p class="tejlg-block-placeholder__message">' . $placeholder_text . '</p></div>';
     }
 }


### PR DESCRIPTION
## Summary
- add a styled placeholder for dynamic blocks to improve visibility in the import preview
- add semantic role and SVG icon markup to highlight the fallback message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dedf0f4d88832e9977a3cec2bee3ef