### PR TITLE
Enhance pattern selection previews

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -284,12 +284,81 @@
 }
 
 .pattern-selection-list li {
-    padding: 0.25rem 0;
     list-style: none;
     margin: 0;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid #e2e4e7;
+}
+
+.pattern-selection-list li:last-child {
+    border-bottom: 0;
 }
 
 .pattern-selection-list li.is-hidden {
+    display: none;
+}
+
+.pattern-selection-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    cursor: pointer;
+}
+
+.pattern-selection-label input[type="checkbox"] {
+    margin-top: 3px;
+}
+
+.pattern-selection-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    width: 100%;
+}
+
+.pattern-selection-title {
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.pattern-selection-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-size: 12px;
+    color: #50575e;
+}
+
+.pattern-selection-date {
+    background: #f0f0f1;
+    border-radius: 999px;
+    padding: 2px 10px;
+    line-height: 1.6;
+}
+
+.pattern-selection-terms {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.pattern-selection-term {
+    background: #2271b1;
+    color: #fff;
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 11px;
+    line-height: 1.6;
+    font-weight: 500;
+}
+
+.pattern-selection-excerpt {
+    font-size: 13px;
+    color: #3c434a;
+    line-height: 1.45;
+}
+
+.pattern-selection-excerpt:empty {
     display: none;
 }
 

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -1248,9 +1248,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
         patternItems.forEach(function(item) {
             const label = item.getAttribute('data-label') || '';
-            const isMatch = label.toLowerCase().indexOf(normalizedQuery) !== -1;
+            const excerpt = item.getAttribute('data-excerpt') || '';
+            const terms = item.getAttribute('data-terms') || '';
+            const date = item.getAttribute('data-date') || '';
+            const haystack = [label, excerpt, terms, date]
+                .join(' ')
+                .toLowerCase();
+            const isMatch = normalizedQuery === '' || haystack.indexOf(normalizedQuery) !== -1;
 
-            if (isMatch || normalizedQuery === '') {
+            if (isMatch) {
                 item.classList.remove('is-hidden');
             } else {
                 item.classList.add('is-hidden');


### PR DESCRIPTION
## Summary
- display excerpt, taxonomy badges, and publication date for each pattern in the export selection list
- style the enriched pattern cards for better readability in the admin
- extend the client-side search to match the new metadata attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee46dd69c832e8cbca123318c4a80