### PR TITLE
Persist export form preferences across admin UI

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -34,6 +34,9 @@ document.addEventListener('DOMContentLoaded', function() {
             const spinner = exportForm.querySelector('[data-export-spinner]');
             const strings = typeof exportAsync.strings === 'object' ? exportAsync.strings : {};
             const pollInterval = typeof exportAsync.pollInterval === 'number' ? exportAsync.pollInterval : 4000;
+            const defaults = (typeof exportAsync.defaults === 'object' && exportAsync.defaults !== null)
+                ? exportAsync.defaults
+                : null;
             const extractResponseMessage = function(payload) {
                 if (!payload || typeof payload !== 'object') {
                     return '';
@@ -54,6 +57,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
             let currentJobId = null;
             let pollTimeout = null;
+
+            if (textarea && defaults && typeof defaults.exclusions === 'string' && !textarea.value) {
+                textarea.value = defaults.exclusions;
+            }
 
             const formatString = function(template, replacements) {
                 if (typeof template !== 'string') {

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -63,6 +63,13 @@ class TEJLG_Admin {
         }
 
         wp_enqueue_script('tejlg-admin-scripts', TEJLG_URL . 'assets/js/admin-scripts.js', [], TEJLG_VERSION, true);
+
+        $saved_exclusions = get_option(TEJLG_Admin_Export_Page::EXCLUSION_PATTERNS_OPTION, '');
+
+        if (!is_string($saved_exclusions)) {
+            $saved_exclusions = '';
+        }
+
         wp_localize_script(
             'tejlg-admin-scripts',
             'tejlgAdminL10n',
@@ -113,6 +120,9 @@ class TEJLG_Admin {
                         'statusLabel'     => esc_html__('Statut de la tâche : %1$s', 'theme-export-jlg'),
                     ],
                     'previousJob' => TEJLG_Export::get_current_user_job_snapshot(),
+                    'defaults'    => [
+                        'exclusions' => $saved_exclusions,
+                    ],
                 ],
             ]
         );

--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -606,6 +606,8 @@ class TEJLG_Export {
         $raw_exclusions = isset($_POST['exclusions']) ? wp_unslash((string) $_POST['exclusions']) : '';
         $exclusions     = [];
 
+        update_option(TEJLG_Admin_Export_Page::EXCLUSION_PATTERNS_OPTION, $raw_exclusions);
+
         if ('' !== $raw_exclusions) {
             $split = preg_split('/[,\r\n]+/', $raw_exclusions);
 

--- a/theme-export-jlg/templates/admin/export-pattern-selection.php
+++ b/theme-export-jlg/templates/admin/export-pattern-selection.php
@@ -5,6 +5,7 @@
 /** @var int       $current_page */
 /** @var int       $total_pages */
 /** @var string    $pagination_base */
+/** @var bool      $portable_mode_enabled */
 
 $back_url = add_query_arg([
     'page' => $page_slug,
@@ -73,7 +74,7 @@ $back_url = add_query_arg([
                 </div>
             <?php endif; ?>
         </div>
-        <p><label><input type="checkbox" name="export_portable" value="1" checked> <strong><?php esc_html_e('Générer un export "portable"', 'theme-export-jlg'); ?></strong> <?php esc_html_e('(Recommandé pour migrer vers un autre site)', 'theme-export-jlg'); ?></label></p>
+        <p><label><input type="checkbox" name="export_portable" value="1" <?php checked($portable_mode_enabled); ?>> <strong><?php esc_html_e('Générer un export "portable"', 'theme-export-jlg'); ?></strong> <?php esc_html_e('(Recommandé pour migrer vers un autre site)', 'theme-export-jlg'); ?></label></p>
 
         <p><button type="submit" name="tejlg_export_selected_patterns" class="button button-primary button-hero"><?php esc_html_e('Exporter la sélection', 'theme-export-jlg'); ?></button></p>
     </form>

--- a/theme-export-jlg/templates/admin/export.php
+++ b/theme-export-jlg/templates/admin/export.php
@@ -2,6 +2,7 @@
 /** @var string $page_slug */
 /** @var string $child_theme_value */
 /** @var string $exclusion_patterns_value */
+/** @var bool   $portable_mode_enabled */
 
 $export_tab_url = add_query_arg([
     'page' => $page_slug,
@@ -59,7 +60,7 @@ $select_patterns_url = add_query_arg([
         <p><?php echo wp_kses_post(__('Générez un fichier <code>.json</code> contenant vos compositions.', 'theme-export-jlg')); ?></p>
         <form method="post" action="">
             <?php wp_nonce_field('tejlg_export_action', 'tejlg_nonce'); ?>
-            <p><label><input type="checkbox" name="export_portable" value="1"> <strong><?php esc_html_e('Export portable', 'theme-export-jlg'); ?></strong> <?php esc_html_e('(compatibilité maximale)', 'theme-export-jlg'); ?></label></p>
+            <p><label><input type="checkbox" name="export_portable" value="1" <?php checked($portable_mode_enabled); ?>> <strong><?php esc_html_e('Export portable', 'theme-export-jlg'); ?></strong> <?php esc_html_e('(compatibilité maximale)', 'theme-export-jlg'); ?></label></p>
             <p><button type="submit" name="tejlg_export_patterns" class="button button-primary"><?php esc_html_e('Exporter TOUTES les compositions', 'theme-export-jlg'); ?></button></p>
         </form>
         <p>


### PR DESCRIPTION
## Summary
- persist export exclusion patterns and portable mode selections via WordPress options when handling admin export forms
- preload stored preferences in the export templates and async script so checkboxes and textareas reflect the saved values
- ensure the async theme export endpoint records the latest exclusion patterns for future sessions

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin-export-page.php
- php -l theme-export-jlg/includes/class-tejlg-admin.php
- php -l theme-export-jlg/includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68dee413cd10832e9c5b0a834201b05d