### PR TITLE
Adjust admin responsive layout

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -6,9 +6,21 @@
     margin-top: 1em;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 782px) {
     .tejlg-cards-container {
         grid-template-columns: 1fr;
+        margin-left: 12px;
+        margin-right: 12px;
+    }
+
+    .nav-tab-wrapper {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .nav-tab-wrapper .nav-tab {
+        margin: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- widen the responsive breakpoint for admin cards to 782px and reduce their horizontal margins on small screens
- allow admin navigation tabs to wrap when viewed on smaller viewports for better accessibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dee54afe78832e85dbee8079dae0aa