### PR TITLE
Adjust admin responsive layout for nav tabs

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -6,9 +6,16 @@
     margin-top: 1em;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 782px) {
     .tejlg-cards-container {
         grid-template-columns: 1fr;
+        margin-inline: 10px;
+    }
+
+    .nav-tab-wrapper {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
     }
 }
 


### PR DESCRIPTION
## Summary
- expand the cards breakpoint to 782px to align with WordPress responsive preview
- reduce side margins for the card grid and allow nav tab wrappers to wrap on small screens

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dee52b2ae8832e8622b91c8ccc4262