### PR TITLE
Add shared block editor styles for Theme Export placeholders

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -118,37 +118,6 @@
     background: #fff;
 }
 
-/* Placeholder pour les blocs dynamiques non rendus */
-.tejlg-block-placeholder {
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-    margin: 12px 0;
-    padding: 16px 18px;
-    border: 2px dashed #2b4a6f;
-    border-radius: 8px;
-    background-color: #f2f5ff;
-    color: #0f213b;
-    font-size: 14px;
-    line-height: 1.5;
-}
-
-.tejlg-block-placeholder:focus-visible {
-    outline: 3px solid #1c64f2;
-    outline-offset: 2px;
-}
-
-.tejlg-block-placeholder__icon {
-    flex: 0 0 auto;
-    width: 24px;
-    height: 24px;
-    color: inherit;
-}
-
-.tejlg-block-placeholder__message {
-    margin: 0;
-}
-
 /* Style pour l'accordéon de débogage */
 #debug-accordion .accordion-section-title {
     border-bottom: 1px solid #ccc;

--- a/theme-export-jlg/assets/css/block-editor.css
+++ b/theme-export-jlg/assets/css/block-editor.css
@@ -1,0 +1,60 @@
+/*
+ * Styles partagés pour l'éditeur de blocs et les aperçus générés par Theme Export - JLG.
+ */
+body.wp-admin .tejlg-block-placeholder,
+body.block-editor-page .tejlg-block-placeholder,
+body.edit-site-page .tejlg-block-placeholder,
+.editor-styles-wrapper .tejlg-block-placeholder {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin: 12px 0;
+    padding: 16px 18px;
+    border: 2px dashed #2b4a6f;
+    border-radius: 8px;
+    background-color: #f2f5ff;
+    color: #0f213b;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+body.block-editor-page .tejlg-block-placeholder:focus-visible,
+body.edit-site-page .tejlg-block-placeholder:focus-visible,
+.editor-styles-wrapper .tejlg-block-placeholder:focus-visible {
+    outline: 3px solid #1c64f2;
+    outline-offset: 2px;
+}
+
+body.wp-admin .tejlg-block-placeholder__icon,
+body.block-editor-page .tejlg-block-placeholder__icon,
+body.edit-site-page .tejlg-block-placeholder__icon,
+.editor-styles-wrapper .tejlg-block-placeholder__icon {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    color: inherit;
+}
+
+body.wp-admin .tejlg-block-placeholder__message,
+body.block-editor-page .tejlg-block-placeholder__message,
+body.edit-site-page .tejlg-block-placeholder__message,
+.editor-styles-wrapper .tejlg-block-placeholder__message {
+    margin: 0;
+}
+
+body.block-editor-page .notice[data-tejlg-notice],
+body.edit-site-page .notice[data-tejlg-notice],
+.editor-styles-wrapper .notice[data-tejlg-notice] {
+    margin: 16px 0;
+    padding: 12px 16px;
+    border-radius: 4px;
+    border-left: 4px solid #dba617;
+    background: #fffbe5;
+    color: #1d2327;
+}
+
+body.block-editor-page .notice[data-tejlg-notice] p,
+body.edit-site-page .notice[data-tejlg-notice] p,
+.editor-styles-wrapper .notice[data-tejlg-notice] p {
+    margin: 0.5em 0;
+}

--- a/theme-export-jlg/templates/admin/import-preview.php
+++ b/theme-export-jlg/templates/admin/import-preview.php
@@ -32,7 +32,7 @@ $global_css_section_id = 'tejlg-global-css';
                 </div>
                 <div class="pattern-preview-wrapper">
                     <iframe class="pattern-preview-iframe" title="<?php echo esc_attr($pattern_data['iframe_title']); ?>" sandbox="allow-same-origin" loading="lazy"></iframe>
-                    <div class="pattern-preview-message notice notice-warning" role="status" aria-live="polite" hidden></div>
+                    <div class="pattern-preview-message notice notice-warning" data-tejlg-notice="warning" role="status" aria-live="polite" hidden></div>
                     <script
                         type="application/json"
                         class="pattern-preview-data"
@@ -74,14 +74,14 @@ $global_css_section_id = 'tejlg-global-css';
             </div>
         <?php endforeach; ?>
         <?php if (!empty($encoding_failures)): ?>
-            <div class="notice notice-warning">
+            <div class="notice notice-warning" data-tejlg-notice="warning">
                 <?php foreach ($encoding_failures as $failure_message): ?>
                     <p><?php echo esc_html($failure_message); ?></p>
                 <?php endforeach; ?>
             </div>
         <?php endif; ?>
         <?php if (!empty($warnings)): ?>
-            <div class="notice notice-warning">
+            <div class="notice notice-warning" data-tejlg-notice="warning">
                 <?php foreach ($warnings as $warning_message): ?>
                     <p><?php echo esc_html($warning_message); ?></p>
                 <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- add a dedicated block editor stylesheet and load it conditionally for plugin placeholders and notices
- share the stylesheet with the admin screens and scope warning markup with a plugin data attribute
- expose filters to let integrators control when the block editor assets are loaded

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68def9aa8454832eaa9083e262aa4105