### PR TITLE
Add search, filters, and sorting to import preview

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -99,6 +99,119 @@
     background: #fff;
 }
 
+.pattern-import-layout {
+    margin-top: 1.5rem;
+}
+
+.pattern-import-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.pattern-import-actions .description {
+    margin: 0;
+    color: #50575e;
+}
+
+.pattern-import-instructions {
+    margin: 0 0 1rem;
+    max-width: 760px;
+    color: #50575e;
+}
+
+.pattern-import-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: flex-end;
+    margin-bottom: 1rem;
+}
+
+.pattern-import-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 180px;
+}
+
+.pattern-import-control--search {
+    flex: 1 1 260px;
+    min-width: 220px;
+}
+
+#tejlg-import-pattern-search,
+#tejlg-import-filter-category,
+#tejlg-import-filter-date,
+#tejlg-import-sort {
+    width: 100%;
+    max-width: 100%;
+    padding: 6px 10px;
+    font-size: 14px;
+    box-sizing: border-box;
+}
+
+#tejlg-import-pattern-search:focus,
+#tejlg-import-filter-category:focus,
+#tejlg-import-filter-date:focus,
+#tejlg-import-sort:focus {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+    outline: none;
+}
+
+.pattern-import-status {
+    margin: 0 0 1rem;
+    font-style: italic;
+    color: #3c434a;
+}
+
+.pattern-import-items .pattern-item {
+    margin-bottom: 20px;
+}
+
+.pattern-item.is-hidden {
+    display: none;
+}
+
+.pattern-import-meta {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.pattern-import-meta-categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.pattern-import-category {
+    display: inline-flex;
+    align-items: center;
+}
+
+.pattern-import-excerpt {
+    margin: 0.5rem 0 0;
+    color: #3c434a;
+    line-height: 1.45;
+}
+
+@media (max-width: 782px) {
+    .pattern-import-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .pattern-import-control {
+        width: 100%;
+        min-width: 0;
+    }
+}
+
 .pattern-selector {
     padding: 10px 15px;
     border-bottom: 1px solid #ccd0d4;

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -95,6 +95,13 @@ class TEJLG_Admin {
                     'empty'          => esc_html__('Aucune composition visible.', 'theme-export-jlg'),
                     'countSingular'  => esc_html__('%s composition visible.', 'theme-export-jlg'),
                     'countPlural'    => esc_html__('%s compositions visibles.', 'theme-export-jlg'),
+                    'filterSearch'   => esc_html__('recherche « %s »', 'theme-export-jlg'),
+                    'filterCategory' => esc_html__('catégorie « %s »', 'theme-export-jlg'),
+                    'filterCategoryNone' => esc_html__('sans catégorie', 'theme-export-jlg'),
+                    'filterDate'     => esc_html__('période « %s »', 'theme-export-jlg'),
+                    'filterDateNone' => esc_html__('sans date', 'theme-export-jlg'),
+                    'filtersSummaryIntro' => esc_html__('Filtres actifs :', 'theme-export-jlg'),
+                    'filtersSummaryJoin'  => esc_html__(' ; ', 'theme-export-jlg'),
                 ],
                 'exportAsync' => [
                     'ajaxUrl' => admin_url('admin-ajax.php'),

--- a/theme-export-jlg/templates/admin/import-preview.php
+++ b/theme-export-jlg/templates/admin/import-preview.php
@@ -5,6 +5,11 @@
 /** @var array  $encoding_failures */
 /** @var array  $warnings */
 /** @var string $global_styles */
+/** @var array  $category_filters */
+/** @var array  $date_filters */
+/** @var bool   $has_uncategorized */
+/** @var bool   $has_undated */
+/** @var string $default_sort */
 
 $import_tab_url    = add_query_arg([
     'page' => $page_slug,
@@ -12,27 +17,156 @@ $import_tab_url    = add_query_arg([
 ], admin_url('admin.php'));
 $has_global_styles      = '' !== trim($global_styles);
 $global_css_section_id = 'tejlg-global-css';
+$category_filters   = is_array($category_filters) ? $category_filters : [];
+$date_filters       = is_array($date_filters) ? $date_filters : [];
+$has_uncategorized  = (bool) $has_uncategorized;
+$has_undated        = (bool) $has_undated;
+$default_sort       = is_string($default_sort) ? trim($default_sort) : 'title-asc';
+if ('' === $default_sort) {
+    $default_sort = 'title-asc';
+}
+$controls_help_id = 'tejlg-import-controls-help';
 ?>
 <h2><?php esc_html_e('Étape 2 : Choisir les compositions à importer', 'theme-export-jlg'); ?></h2>
 <p><?php esc_html_e('Cochez les compositions à importer. Vous pouvez prévisualiser le rendu et inspecter le code du bloc (le code CSS du thème est masqué par défaut).', 'theme-export-jlg'); ?></p>
 <form method="post" action="<?php echo esc_url($import_tab_url); ?>">
     <?php wp_nonce_field('tejlg_import_patterns_step2_action', 'tejlg_import_patterns_step2_nonce'); ?>
     <input type="hidden" name="transient_id" value="<?php echo esc_attr($transient_id); ?>">
-    <div id="patterns-preview-list">
-        <div style="margin-bottom:15px;">
-            <label><input type="checkbox" id="select-all-patterns" checked> <strong><?php esc_html_e('Tout sélectionner', 'theme-export-jlg'); ?></strong></label>
+    <div
+        id="patterns-preview-list"
+        class="pattern-import-layout"
+        data-default-sort="<?php echo esc_attr($default_sort); ?>"
+    >
+        <div class="pattern-import-actions">
+            <label>
+                <input
+                    type="checkbox"
+                    id="select-all-patterns"
+                    checked
+                    aria-describedby="<?php echo esc_attr($controls_help_id); ?>"
+                >
+                <strong><?php esc_html_e('Tout sélectionner', 'theme-export-jlg'); ?></strong>
+            </label>
+            <p class="description">
+                <?php esc_html_e('La case « Tout sélectionner » agit uniquement sur les compositions visibles après application de la recherche, des filtres et du tri.', 'theme-export-jlg'); ?>
+            </p>
         </div>
-        <?php foreach ($patterns as $pattern_data): ?>
-            <div class="pattern-item">
-                <div class="pattern-selector">
-                    <label>
-                        <input type="checkbox" name="selected_patterns[]" value="<?php echo esc_attr($pattern_data['index']); ?>" checked>
-                        <strong><?php echo esc_html($pattern_data['title']); ?></strong>
-                    </label>
-                </div>
-                <div class="pattern-preview-wrapper">
-                    <iframe class="pattern-preview-iframe" title="<?php echo esc_attr($pattern_data['iframe_title']); ?>" sandbox="allow-same-origin" loading="lazy"></iframe>
-                    <div class="pattern-preview-message notice notice-warning" role="status" aria-live="polite" hidden></div>
+        <p id="<?php echo esc_attr($controls_help_id); ?>" class="pattern-import-instructions">
+            <?php esc_html_e('Utilisez la recherche, les filtres (catégorie, période) et le tri pour réduire la liste. Le compteur suivant annonce en continu le nombre de compositions visibles aux lecteurs d’écran.', 'theme-export-jlg'); ?>
+        </p>
+        <div class="pattern-import-toolbar" role="group" aria-label="<?php esc_attr_e('Filtres d’importation des compositions', 'theme-export-jlg'); ?>">
+            <div class="pattern-import-control pattern-import-control--search">
+                <label class="screen-reader-text" for="tejlg-import-pattern-search"><?php esc_html_e('Rechercher une composition à importer', 'theme-export-jlg'); ?></label>
+                <input
+                    type="search"
+                    id="tejlg-import-pattern-search"
+                    placeholder="<?php echo esc_attr__('Rechercher…', 'theme-export-jlg'); ?>"
+                    aria-describedby="<?php echo esc_attr($controls_help_id); ?>"
+                    aria-controls="patterns-preview-items"
+                >
+            </div>
+            <div class="pattern-import-control">
+                <label for="tejlg-import-filter-category"><?php esc_html_e('Catégorie', 'theme-export-jlg'); ?></label>
+                <select
+                    id="tejlg-import-filter-category"
+                    aria-describedby="<?php echo esc_attr($controls_help_id); ?>"
+                >
+                    <option value=""><?php esc_html_e('Toutes les catégories', 'theme-export-jlg'); ?></option>
+                    <?php foreach ($category_filters as $value => $label): ?>
+                        <option value="<?php echo esc_attr($value); ?>"><?php echo esc_html($label); ?></option>
+                    <?php endforeach; ?>
+                    <?php if ($has_uncategorized): ?>
+                        <option value="__no-category__"><?php esc_html_e('Sans catégorie', 'theme-export-jlg'); ?></option>
+                    <?php endif; ?>
+                </select>
+            </div>
+            <div class="pattern-import-control">
+                <label for="tejlg-import-filter-date"><?php esc_html_e('Période', 'theme-export-jlg'); ?></label>
+                <select
+                    id="tejlg-import-filter-date"
+                    aria-describedby="<?php echo esc_attr($controls_help_id); ?>"
+                >
+                    <option value=""><?php esc_html_e('Toutes les périodes', 'theme-export-jlg'); ?></option>
+                    <?php foreach ($date_filters as $value => $label): ?>
+                        <option value="<?php echo esc_attr($value); ?>"><?php echo esc_html($label); ?></option>
+                    <?php endforeach; ?>
+                    <?php if ($has_undated): ?>
+                        <option value="__no-date__"><?php esc_html_e('Sans date', 'theme-export-jlg'); ?></option>
+                    <?php endif; ?>
+                </select>
+            </div>
+            <div class="pattern-import-control">
+                <label for="tejlg-import-sort"><?php esc_html_e('Trier par', 'theme-export-jlg'); ?></label>
+                <select
+                    id="tejlg-import-sort"
+                    aria-describedby="<?php echo esc_attr($controls_help_id); ?>"
+                >
+                    <option value="title-asc" <?php selected($default_sort, 'title-asc'); ?>><?php esc_html_e('Titre (A → Z)', 'theme-export-jlg'); ?></option>
+                    <option value="title-desc" <?php selected($default_sort, 'title-desc'); ?>><?php esc_html_e('Titre (Z → A)', 'theme-export-jlg'); ?></option>
+                    <option value="date-desc" <?php selected($default_sort, 'date-desc'); ?>><?php esc_html_e('Date (du plus récent au plus ancien)', 'theme-export-jlg'); ?></option>
+                    <option value="date-asc" <?php selected($default_sort, 'date-asc'); ?>><?php esc_html_e('Date (du plus ancien au plus récent)', 'theme-export-jlg'); ?></option>
+                    <option value="original" <?php selected($default_sort, 'original'); ?>><?php esc_html_e('Ordre du fichier importé', 'theme-export-jlg'); ?></option>
+                </select>
+            </div>
+        </div>
+        <p id="pattern-import-status" class="pattern-import-status" aria-live="polite" aria-atomic="true"></p>
+        <div class="pattern-import-items" id="patterns-preview-items" data-searchable="true">
+            <?php foreach ($patterns as $pattern_data): ?>
+                <?php
+                $category_tokens = isset($pattern_data['categories']) && is_array($pattern_data['categories'])
+                    ? array_filter($pattern_data['categories'], 'is_scalar')
+                    : [];
+                $category_tokens_attr = implode(' ', array_map('sanitize_title', $category_tokens));
+                $period_value = isset($pattern_data['period_value']) ? (string) $pattern_data['period_value'] : '';
+                $date_machine = isset($pattern_data['date_machine']) ? (string) $pattern_data['date_machine'] : '';
+                $timestamp_value = isset($pattern_data['timestamp']) && null !== $pattern_data['timestamp']
+                    ? (string) (int) $pattern_data['timestamp']
+                    : '';
+                $search_haystack = isset($pattern_data['search_haystack']) ? (string) $pattern_data['search_haystack'] : '';
+                $title_sort = isset($pattern_data['title_sort']) ? (string) $pattern_data['title_sort'] : '';
+                $original_index = isset($pattern_data['original_index']) ? (int) $pattern_data['original_index'] : 0;
+                $category_labels = isset($pattern_data['category_labels']) && is_array($pattern_data['category_labels'])
+                    ? array_filter($pattern_data['category_labels'], 'is_scalar')
+                    : [];
+                $excerpt = isset($pattern_data['excerpt']) ? (string) $pattern_data['excerpt'] : '';
+                $date_display = isset($pattern_data['date_display']) ? (string) $pattern_data['date_display'] : '';
+                ?>
+                <div
+                    class="pattern-item"
+                    data-search="<?php echo esc_attr($search_haystack); ?>"
+                    data-categories="<?php echo esc_attr($category_tokens_attr); ?>"
+                    data-period="<?php echo esc_attr($period_value); ?>"
+                    data-date="<?php echo esc_attr($date_machine); ?>"
+                    data-timestamp="<?php echo esc_attr($timestamp_value); ?>"
+                    data-title-sort="<?php echo esc_attr($title_sort); ?>"
+                    data-original-index="<?php echo esc_attr($original_index); ?>"
+                >
+                    <div class="pattern-selector">
+                        <label>
+                            <input type="checkbox" name="selected_patterns[]" value="<?php echo esc_attr($pattern_data['index']); ?>" checked>
+                            <strong><?php echo esc_html($pattern_data['title']); ?></strong>
+                        </label>
+                        <?php if ('' !== $date_display || !empty($category_labels)): ?>
+                            <div class="pattern-import-meta">
+                                <?php if ('' !== $date_display): ?>
+                                    <span class="pattern-import-meta-date pattern-selection-date"><?php echo esc_html($date_display); ?></span>
+                                <?php endif; ?>
+                                <?php if (!empty($category_labels)): ?>
+                                    <span class="pattern-import-meta-categories" aria-label="<?php echo esc_attr__('Catégories associées', 'theme-export-jlg'); ?>">
+                                        <?php foreach ($category_labels as $category_label): ?>
+                                            <span class="pattern-import-category pattern-selection-term"><?php echo esc_html($category_label); ?></span>
+                                        <?php endforeach; ?>
+                                    </span>
+                                <?php endif; ?>
+                            </div>
+                        <?php endif; ?>
+                        <?php if ('' !== $excerpt): ?>
+                            <p class="pattern-import-excerpt"><?php echo esc_html($excerpt); ?></p>
+                        <?php endif; ?>
+                    </div>
+                    <div class="pattern-preview-wrapper">
+                        <iframe class="pattern-preview-iframe" title="<?php echo esc_attr($pattern_data['iframe_title']); ?>" sandbox="allow-same-origin" loading="lazy"></iframe>
+                        <div class="pattern-preview-message notice notice-warning" role="status" aria-live="polite" hidden></div>
                     <script
                         type="application/json"
                         class="pattern-preview-data"
@@ -71,8 +205,9 @@ $global_css_section_id = 'tejlg-global-css';
                     <?php endif; ?>
                 </div>
 
-            </div>
-        <?php endforeach; ?>
+                </div>
+            <?php endforeach; ?>
+        </div>
         <?php if (!empty($encoding_failures)): ?>
             <div class="notice notice-warning">
                 <?php foreach ($encoding_failures as $failure_message): ?>


### PR DESCRIPTION
## Summary
- add documented search, category/date filters, sorting options, and a live status bar to the pattern import preview step
- expose pattern metadata (categories, dates, excerpts, normalized search data) when preparing the import session so the UI can filter and sort entries
- refactor the admin script to drive search/select-all/status logic for both export and import lists and style the new import controls

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin-import-page.php
- php -l theme-export-jlg/templates/admin/import-preview.php
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68def9b00cbc832e868c59443aea8b8c