### PR TITLE
Add mobile-friendly admin tab navigation

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -1,3 +1,118 @@
+/* Navigation principale du plugin */
+.tejlg-admin-nav {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+
+.tejlg-admin-nav__mobile {
+    display: none;
+    align-items: center;
+    gap: 10px;
+    position: relative;
+}
+
+.tejlg-admin-nav__current {
+    display: none;
+    font-weight: 600;
+    color: #1d2327;
+    padding: 6px 10px;
+    border-radius: 4px;
+    background-color: #f6f7f7;
+    border: 1px solid #d0d3d6;
+}
+
+.tejlg-admin-nav__select {
+    display: none;
+    min-width: 220px;
+    padding: 6px 34px 6px 12px;
+    border: 1px solid #8c8f94;
+    border-radius: 4px;
+    background-color: #fff;
+    background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+        linear-gradient(135deg, currentColor 50%, transparent 50%),
+        linear-gradient(to right, #dcdcde, #dcdcde);
+    background-position: calc(100% - 16px) calc(50% - 3px),
+        calc(100% - 10px) calc(50% - 3px),
+        calc(100% - 2.5em) 50%;
+    background-size: 6px 6px, 6px 6px, 1px 60%;
+    background-repeat: no-repeat;
+    color: inherit;
+    cursor: pointer;
+    appearance: none;
+}
+
+.tejlg-admin-nav__select:focus-visible {
+    outline: 2px solid var(--wp-admin-theme-color, #007cba);
+    outline-offset: 2px;
+}
+
+.tejlg-admin-nav .nav-tab {
+    position: relative;
+    transition: color 0.2s ease;
+}
+
+.tejlg-admin-nav .nav-tab::after {
+    content: '';
+    position: absolute;
+    left: 12px;
+    right: 12px;
+    bottom: -1px;
+    height: 3px;
+    border-radius: 3px 3px 0 0;
+    background-color: transparent;
+    transition: background-color 0.2s ease;
+}
+
+.tejlg-admin-nav .nav-tab:hover {
+    color: var(--wp-admin-theme-color, #007cba);
+}
+
+.tejlg-admin-nav .nav-tab.nav-tab-active::after {
+    background-color: var(--wp-admin-theme-color, #007cba);
+}
+
+@media (max-width: 960px) {
+    .tejlg-admin-nav__current {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .tejlg-admin-nav__current::before {
+        content: '';
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background-color: var(--wp-admin-theme-color, #007cba);
+        box-shadow: 0 0 0 2px rgba(0, 124, 186, 0.15);
+    }
+}
+
+@media (max-width: 782px) {
+    .tejlg-admin-nav {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 16px;
+    }
+
+    .tejlg-admin-nav__mobile {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    .tejlg-admin-nav__select {
+        display: block;
+        width: 100%;
+    }
+
+    .tejlg-admin-nav .nav-tab-wrapper {
+        display: none;
+    }
+}
+
 /* Style des cartes pour les onglets */
 .tejlg-cards-container {
     display: grid;

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -20,6 +20,85 @@ document.addEventListener('DOMContentLoaded', function() {
         ? localization.exportAsync
         : null;
 
+    const adminNavContainers = document.querySelectorAll('[data-tejlg-admin-nav]');
+
+    if (adminNavContainers.length) {
+        adminNavContainers.forEach(function(container) {
+            const select = container.querySelector('[data-tejlg-nav-select]');
+            const navLinks = container.querySelectorAll('[data-tejlg-nav-link]');
+            const currentLabel = container.querySelector('[data-tejlg-nav-current]');
+
+            if (!select || !navLinks.length) {
+                return;
+            }
+
+            const updateSelectFromActive = function() {
+                const activeLink = container.querySelector('.nav-tab-active[data-tejlg-nav-link]');
+
+                if (activeLink) {
+                    const tabId = activeLink.getAttribute('data-tejlg-tab');
+                    if (tabId) {
+                        select.value = tabId;
+                    }
+                }
+
+                if (currentLabel && select.options.length) {
+                    const selectedOption = select.options[select.selectedIndex];
+                    if (selectedOption) {
+                        currentLabel.textContent = selectedOption.textContent;
+                    }
+                }
+            };
+
+            const updateLabelFromSelect = function() {
+                if (currentLabel && select.options.length) {
+                    const selectedOption = select.options[select.selectedIndex];
+                    if (selectedOption) {
+                        currentLabel.textContent = selectedOption.textContent;
+                    }
+                }
+            };
+
+            updateSelectFromActive();
+
+            select.addEventListener('change', function(event) {
+                const target = event.target;
+                if (!target) {
+                    return;
+                }
+
+                const selectedTab = target.value;
+                updateLabelFromSelect();
+
+                if (!selectedTab) {
+                    return;
+                }
+
+                let matchingLink = null;
+
+                navLinks.forEach(function(link) {
+                    if (!matchingLink && link.getAttribute('data-tejlg-tab') === selectedTab) {
+                        matchingLink = link;
+                    }
+                });
+
+                if (matchingLink && matchingLink.href) {
+                    window.location.href = matchingLink.href;
+                }
+            });
+
+            navLinks.forEach(function(link) {
+                link.addEventListener('click', function() {
+                    const tabId = link.getAttribute('data-tejlg-tab');
+                    if (tabId) {
+                        select.value = tabId;
+                        updateLabelFromSelect();
+                    }
+                });
+            });
+        });
+    }
+
     if (exportAsync) {
         const exportForm = document.querySelector('[data-export-form]');
 

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -140,15 +140,61 @@ class TEJLG_Admin {
 
     public function render_admin_page() {
         $active_tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'export';
+
+        $tabs = [
+            'export' => [
+                'label' => __('Exporter & Outils', 'theme-export-jlg'),
+            ],
+            'import' => [
+                'label' => __('Importer', 'theme-export-jlg'),
+            ],
+            'migration_guide' => [
+                'label' => __('Guide de Migration', 'theme-export-jlg'),
+            ],
+            'debug' => [
+                'label' => __('Débogage', 'theme-export-jlg'),
+            ],
+        ];
+
+        foreach ($tabs as $tab_key => &$tab_data) {
+            $tab_data['url'] = esc_url(add_query_arg([
+                'page' => $this->page_slug,
+                'tab'  => $tab_key,
+            ], admin_url('admin.php')));
+        }
+        unset($tab_data);
+
+        if (!array_key_exists($active_tab, $tabs)) {
+            $active_tab = 'export';
+        }
+
+        $select_id = 'tejlg-admin-tab-select';
         ?>
         <div class="wrap">
             <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
-            <h2 class="nav-tab-wrapper">
-                <a href="<?php echo esc_url(add_query_arg(['page' => $this->page_slug, 'tab' => 'export'], admin_url('admin.php'))); ?>" class="nav-tab <?php echo $active_tab === 'export' ? 'nav-tab-active' : ''; ?>"><?php esc_html_e('Exporter & Outils', 'theme-export-jlg'); ?></a>
-                <a href="<?php echo esc_url(add_query_arg(['page' => $this->page_slug, 'tab' => 'import'], admin_url('admin.php'))); ?>" class="nav-tab <?php echo $active_tab === 'import' ? 'nav-tab-active' : ''; ?>"><?php esc_html_e('Importer', 'theme-export-jlg'); ?></a>
-                <a href="<?php echo esc_url(add_query_arg(['page' => $this->page_slug, 'tab' => 'migration_guide'], admin_url('admin.php'))); ?>" class="nav-tab <?php echo $active_tab === 'migration_guide' ? 'nav-tab-active' : ''; ?>"><?php esc_html_e('Guide de Migration', 'theme-export-jlg'); ?></a>
-                <a href="<?php echo esc_url(add_query_arg(['page' => $this->page_slug, 'tab' => 'debug'], admin_url('admin.php'))); ?>" class="nav-tab <?php echo $active_tab === 'debug' ? 'nav-tab-active' : ''; ?>"><?php esc_html_e('Débogage', 'theme-export-jlg'); ?></a>
-            </h2>
+            <div class="tejlg-admin-nav" data-tejlg-admin-nav>
+                <label class="screen-reader-text" for="<?php echo esc_attr($select_id); ?>"><?php esc_html_e('Sélectionner un onglet d’administration', 'theme-export-jlg'); ?></label>
+                <div class="tejlg-admin-nav__mobile" aria-hidden="false">
+                    <span class="tejlg-admin-nav__current" data-tejlg-nav-current aria-hidden="true"><?php echo isset($tabs[$active_tab]['label']) ? esc_html($tabs[$active_tab]['label']) : ''; ?></span>
+                    <select id="<?php echo esc_attr($select_id); ?>" class="tejlg-admin-nav__select" data-tejlg-nav-select>
+                        <?php foreach ($tabs as $tab_key => $tab_data) : ?>
+                            <option value="<?php echo esc_attr($tab_key); ?>" <?php selected($active_tab, $tab_key); ?>><?php echo esc_html($tab_data['label']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <h2 class="nav-tab-wrapper" role="tablist">
+                    <?php foreach ($tabs as $tab_key => $tab_data) : ?>
+                        <a
+                            href="<?php echo $tab_data['url']; ?>"
+                            class="nav-tab <?php echo $active_tab === $tab_key ? 'nav-tab-active' : ''; ?>"
+                            data-tejlg-nav-link
+                            data-tejlg-tab="<?php echo esc_attr($tab_key); ?>"
+                        >
+                            <?php echo esc_html($tab_data['label']); ?>
+                        </a>
+                    <?php endforeach; ?>
+                </h2>
+            </div>
             <?php
             switch ($active_tab) {
                 case 'import':


### PR DESCRIPTION
## Summary
- add a responsive navigation wrapper for admin tabs with a mobile select fallback
- style the admin navigation for desktop and mobile with visual indicators
- synchronize the active state between the select control and tab links via JavaScript

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68def9b17004832e8c250807d6012230