### PR TITLE
Refine theme export exclusions UI and persistence

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -64,10 +64,17 @@ class TEJLG_Admin {
 
         wp_enqueue_script('tejlg-admin-scripts', TEJLG_URL . 'assets/js/admin-scripts.js', [], TEJLG_VERSION, true);
 
-        $saved_exclusions = get_option(TEJLG_Admin_Export_Page::EXCLUSION_PATTERNS_OPTION, '');
+        $saved_selection = TEJLG_Admin_Export_Page::get_saved_exclusion_preferences();
+        $exclusion_presets = TEJLG_Admin_Export_Page::get_exclusion_presets_catalog();
 
-        if (!is_string($saved_exclusions)) {
-            $saved_exclusions = '';
+        $presets_for_js = [];
+
+        foreach ($exclusion_presets as $key => $config) {
+            $presets_for_js[] = [
+                'key'      => $key,
+                'label'    => isset($config['label']) ? $config['label'] : $key,
+                'patterns' => isset($config['patterns']) ? array_values((array) $config['patterns']) : [],
+            ];
         }
 
         wp_localize_script(
@@ -121,7 +128,16 @@ class TEJLG_Admin {
                     ],
                     'previousJob' => TEJLG_Export::get_current_user_job_snapshot(),
                     'defaults'    => [
-                        'exclusions' => $saved_exclusions,
+                        'presets'    => $saved_selection['presets'],
+                        'custom'     => $saved_selection['custom'],
+                    ],
+                ],
+                'exclusions' => [
+                    'presets'         => $presets_for_js,
+                    'selectedPresets' => $saved_selection['presets'],
+                    'custom'          => $saved_selection['custom'],
+                    'strings'         => [
+                        'summaryEmpty' => esc_html__('Aucun motif d’exclusion sélectionné.', 'theme-export-jlg'),
                     ],
                 ],
             ]

--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -603,30 +603,9 @@ class TEJLG_Export {
 
         check_ajax_referer('tejlg_start_theme_export', 'nonce');
 
-        $raw_exclusions = isset($_POST['exclusions']) ? wp_unslash((string) $_POST['exclusions']) : '';
-        $exclusions     = [];
-
-        update_option(TEJLG_Admin_Export_Page::EXCLUSION_PATTERNS_OPTION, $raw_exclusions);
-
-        if ('' !== $raw_exclusions) {
-            $split = preg_split('/[,\r\n]+/', $raw_exclusions);
-
-            if (false !== $split) {
-                $exclusions = array_values(
-                    array_filter(
-                        array_map(
-                            static function ($pattern) {
-                                return trim((string) $pattern);
-                            },
-                            $split
-                        ),
-                        static function ($pattern) {
-                            return '' !== $pattern;
-                        }
-                    )
-                );
-            }
-        }
+        $selection  = TEJLG_Admin_Export_Page::extract_exclusion_selection_from_request($_POST);
+        TEJLG_Admin_Export_Page::store_exclusion_preferences($selection);
+        $exclusions = TEJLG_Admin_Export_Page::build_exclusion_list($selection);
 
         $result = self::export_theme($exclusions);
 

--- a/theme-export-jlg/templates/admin/export.php
+++ b/theme-export-jlg/templates/admin/export.php
@@ -1,7 +1,10 @@
 <?php
 /** @var string $page_slug */
 /** @var string $child_theme_value */
-/** @var string $exclusion_patterns_value */
+/** @var array  $exclusion_presets */
+/** @var array  $selected_exclusion_presets */
+/** @var string $exclusion_custom_value */
+/** @var array  $exclusion_summary */
 /** @var bool   $portable_mode_enabled */
 
 $export_tab_url = add_query_arg([
@@ -28,18 +31,69 @@ $select_patterns_url = add_query_arg([
             data-export-form
         >
             <?php wp_nonce_field('tejlg_theme_export_action', 'tejlg_theme_export_nonce'); ?>
-            <p>
-                <label for="tejlg_exclusion_patterns"><?php esc_html_e('Motifs d\'exclusion (optionnel) :', 'theme-export-jlg'); ?></label><br>
-                <textarea
-                    name="tejlg_exclusion_patterns"
-                    id="tejlg_exclusion_patterns"
-                    class="large-text code"
-                    rows="4"
-                    placeholder="<?php echo esc_attr__('Ex. : assets/*.scss', 'theme-export-jlg'); ?>"
-                    aria-describedby="tejlg_exclusion_patterns_description"
-                ><?php echo esc_textarea($exclusion_patterns_value); ?></textarea>
-                <span id="tejlg_exclusion_patterns_description" class="description"><?php esc_html_e('Indiquez un motif par ligne ou séparez-les par des virgules (joker * accepté).', 'theme-export-jlg'); ?></span>
-            </p>
+            <fieldset class="tejlg-exclusion-fieldset">
+                <legend><?php esc_html_e("Motifs d'exclusion", 'theme-export-jlg'); ?></legend>
+                <p class="description"><?php esc_html_e('Sélectionnez les éléments à exclure de l’archive. Ajoutez des motifs personnalisés si nécessaire.', 'theme-export-jlg'); ?></p>
+                <div class="tejlg-exclusion-presets" role="group" aria-label="<?php echo esc_attr__("Motifs d'exclusion prédéfinis", 'theme-export-jlg'); ?>">
+                    <?php foreach ($exclusion_presets as $preset_key => $preset_config) :
+                        $preset_id = 'tejlg_exclusion_preset_' . sanitize_html_class($preset_key);
+                        $is_checked = in_array($preset_key, $selected_exclusion_presets, true);
+                        ?>
+                        <label for="<?php echo esc_attr($preset_id); ?>" class="tejlg-exclusion-preset">
+                            <input
+                                type="checkbox"
+                                name="tejlg_exclusion_presets[]"
+                                id="<?php echo esc_attr($preset_id); ?>"
+                                value="<?php echo esc_attr($preset_key); ?>"
+                                <?php checked($is_checked); ?>
+                                data-exclusion-preset
+                            >
+                            <span class="tejlg-exclusion-preset-label"><?php echo esc_html($preset_config['label']); ?></span>
+                            <?php if (!empty($preset_config['description'])) : ?>
+                                <span class="description"><?php echo esc_html($preset_config['description']); ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($preset_config['patterns'])) : ?>
+                                <span class="screen-reader-text"><?php esc_html_e('Motifs exclus :', 'theme-export-jlg'); ?></span>
+                                <ul class="tejlg-exclusion-patterns">
+                                    <?php foreach ((array) $preset_config['patterns'] as $pattern) : ?>
+                                        <li><code><?php echo esc_html((string) $pattern); ?></code></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php endif; ?>
+                        </label>
+                    <?php endforeach; ?>
+                </div>
+                <div class="tejlg-exclusion-custom">
+                    <label for="tejlg_exclusion_custom" class="tejlg-exclusion-custom-label"><?php esc_html_e('Motifs personnalisés', 'theme-export-jlg'); ?></label>
+                    <input
+                        type="text"
+                        name="tejlg_exclusion_custom"
+                        id="tejlg_exclusion_custom"
+                        class="regular-text"
+                        value="<?php echo esc_attr($exclusion_custom_value); ?>"
+                        placeholder="<?php echo esc_attr__('Ex. : assets/*.scss, *.map', 'theme-export-jlg'); ?>"
+                        data-exclusion-custom
+                        aria-describedby="tejlg_exclusion_custom_description"
+                    >
+                    <p id="tejlg_exclusion_custom_description" class="description"><?php esc_html_e('Séparez plusieurs motifs par une virgule.', 'theme-export-jlg'); ?></p>
+                </div>
+                <div class="tejlg-exclusion-summary">
+                    <strong><?php esc_html_e('Motifs actuellement exclus :', 'theme-export-jlg'); ?></strong>
+                    <ul
+                        class="tejlg-exclusion-summary-list"
+                        data-exclusion-summary
+                        data-empty-text="<?php echo esc_attr__('Aucun motif d’exclusion sélectionné.', 'theme-export-jlg'); ?>"
+                    >
+                        <?php if (empty($exclusion_summary)) : ?>
+                            <li class="description" data-summary-empty><?php esc_html_e('Aucun motif d’exclusion sélectionné.', 'theme-export-jlg'); ?></li>
+                        <?php else : ?>
+                            <?php foreach ($exclusion_summary as $pattern) : ?>
+                                <li><code><?php echo esc_html($pattern); ?></code></li>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </ul>
+                </div>
+            </fieldset>
             <p class="tejlg-theme-export-actions">
                 <button type="submit" class="button button-primary" data-export-start><?php esc_html_e("Lancer l'export du thème", 'theme-export-jlg'); ?></button>
                 <span class="spinner" aria-hidden="true" data-export-spinner></span>


### PR DESCRIPTION
## Summary
- replace the single exclusion textarea with preset checkboxes, a custom pattern input, and a live summary in the export form
- persist exclusion selections as preset keys plus custom motifs and merge them when launching synchronous or asynchronous exports
- localize the preset catalogue to the admin script, update the async flow to post the structured selection, and adjust tests for the new storage format

## Testing
- php -l theme-export-jlg/includes/class-tejlg-admin-export-page.php
- php -l theme-export-jlg/includes/class-tejlg-admin.php
- php -l theme-export-jlg/includes/class-tejlg-export.php
- npm run test:php *(fails: phpunit not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68def9a51680832e9dcce0149c05434b