### PR TITLE
Refactor admin preview loading

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -235,6 +235,110 @@
     background: var(--tejlg-surface-muted-color);
 }
 
+.pattern-preview-compact {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+}
+
+.pattern-preview-compact-thumbnail {
+    position: relative;
+    flex: 0 0 88px;
+    height: 66px;
+    border: 1px dashed var(--tejlg-border-color);
+    border-radius: var(--wp-admin-border-radius, 6px);
+    background: var(--tejlg-surface-color);
+    overflow: hidden;
+}
+
+.pattern-preview-compact-thumbnail::before,
+.pattern-preview-compact-thumbnail::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+}
+
+.pattern-preview-compact-thumbnail::before {
+    background: linear-gradient(135deg, color-mix(in srgb, var(--tejlg-accent-color) 18%, transparent), transparent 65%);
+    opacity: 0.45;
+}
+
+.pattern-preview-compact-thumbnail::after {
+    background:
+        repeating-linear-gradient(
+            90deg,
+            color-mix(in srgb, var(--tejlg-border-color) 70%, transparent) 0,
+            color-mix(in srgb, var(--tejlg-border-color) 70%, transparent) 12px,
+            transparent 12px,
+            transparent 24px
+        );
+    opacity: 0.4;
+}
+
+.pattern-preview-compact-details {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.pattern-preview-compact-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    font-size: 13px;
+    color: var(--tejlg-text-muted-color);
+}
+
+.pattern-preview-compact-date {
+    font-weight: 500;
+}
+
+.pattern-preview-compact-categories {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.pattern-preview-compact-category {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: var(--wp-admin-border-radius, 999px);
+    background: color-mix(in srgb, var(--tejlg-accent-color) 12%, transparent);
+    color: var(--tejlg-accent-color-darker);
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.pattern-preview-live {
+    margin-top: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.pattern-preview-trigger--collapse {
+    align-self: flex-end;
+}
+
+.pattern-preview-loading {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.pattern-preview-loading .spinner {
+    visibility: visible;
+    margin: 0;
+}
+
+.pattern-preview-loading-text {
+    font-size: 13px;
+}
+
 .pattern-preview-iframe {
     width: 100%;
     min-height: 250px;

--- a/theme-export-jlg/templates/admin/import-preview.php
+++ b/theme-export-jlg/templates/admin/import-preview.php
@@ -141,6 +141,7 @@ $controls_help_id = 'tejlg-import-controls-help';
                     data-title-sort="<?php echo esc_attr($title_sort); ?>"
                     data-original-index="<?php echo esc_attr($original_index); ?>"
                 >
+                    <?php $preview_live_id = 'pattern-preview-live-' . (int) $pattern_data['index']; ?>
                     <div class="pattern-selector">
                         <label>
                             <input type="checkbox" name="selected_patterns[]" value="<?php echo esc_attr($pattern_data['index']); ?>" checked>
@@ -164,16 +165,64 @@ $controls_help_id = 'tejlg-import-controls-help';
                             <p class="pattern-import-excerpt"><?php echo esc_html($excerpt); ?></p>
                         <?php endif; ?>
                     </div>
-                    <div class="pattern-preview-wrapper">
-                        <iframe class="pattern-preview-iframe" title="<?php echo esc_attr($pattern_data['iframe_title']); ?>" sandbox="allow-same-origin" loading="lazy"></iframe>
-                        <div class="pattern-preview-message notice notice-warning" role="status" aria-live="polite" hidden></div>
-                    <script
-                        type="application/json"
-                        class="pattern-preview-data"
-                        data-tejlg-stylesheets="<?php echo esc_attr($pattern_data['iframe_stylesheets_json']); ?>"
-                        data-tejlg-stylesheet-links-html="<?php echo esc_attr(isset($pattern_data['iframe_stylesheet_links_json']) ? $pattern_data['iframe_stylesheet_links_json'] : '""'); ?>"
-                    ><?php echo $pattern_data['iframe_json']; ?></script>
-                </div>
+                    <div class="pattern-preview-wrapper" data-preview-state="compact">
+                        <div class="pattern-preview-compact" data-preview-compact>
+                            <div class="pattern-preview-compact-thumbnail" aria-hidden="true"></div>
+                            <div class="pattern-preview-compact-details">
+                                <?php if ('' !== $date_display || !empty($category_labels)): ?>
+                                    <div class="pattern-preview-compact-meta">
+                                        <?php if ('' !== $date_display): ?>
+                                            <span class="pattern-preview-compact-date"><?php echo esc_html($date_display); ?></span>
+                                        <?php endif; ?>
+                                        <?php if (!empty($category_labels)): ?>
+                                            <span class="pattern-preview-compact-categories" aria-label="<?php echo esc_attr__('Catégories associées', 'theme-export-jlg'); ?>">
+                                                <?php foreach ($category_labels as $category_label): ?>
+                                                    <span class="pattern-preview-compact-category"><?php echo esc_html($category_label); ?></span>
+                                                <?php endforeach; ?>
+                                            </span>
+                                        <?php endif; ?>
+                                    </div>
+                                <?php endif; ?>
+                                <button
+                                    type="button"
+                                    class="button button-secondary pattern-preview-trigger"
+                                    data-preview-trigger="expand"
+                                    aria-controls="<?php echo esc_attr($preview_live_id); ?>"
+                                    aria-expanded="false"
+                                >
+                                    <?php esc_html_e('Prévisualiser', 'theme-export-jlg'); ?>
+                                </button>
+                            </div>
+                        </div>
+                        <div
+                            class="pattern-preview-live"
+                            data-preview-live
+                            id="<?php echo esc_attr($preview_live_id); ?>"
+                            hidden
+                        >
+                            <button
+                                type="button"
+                                class="button-link pattern-preview-trigger pattern-preview-trigger--collapse"
+                                data-preview-trigger="collapse"
+                                aria-controls="<?php echo esc_attr($preview_live_id); ?>"
+                                aria-expanded="true"
+                            >
+                                <?php esc_html_e('Masquer la prévisualisation', 'theme-export-jlg'); ?>
+                            </button>
+                            <div class="pattern-preview-loading" data-preview-loading role="status" aria-live="polite" hidden>
+                                <span class="spinner is-active" aria-hidden="true"></span>
+                                <span class="pattern-preview-loading-text"><?php esc_html_e('Chargement de la prévisualisation…', 'theme-export-jlg'); ?></span>
+                            </div>
+                            <iframe class="pattern-preview-iframe" title="<?php echo esc_attr($pattern_data['iframe_title']); ?>" sandbox="allow-same-origin" loading="lazy"></iframe>
+                            <div class="pattern-preview-message notice notice-warning" role="status" aria-live="polite" hidden></div>
+                            <script
+                                type="application/json"
+                                class="pattern-preview-data"
+                                data-tejlg-stylesheets="<?php echo esc_attr($pattern_data['iframe_stylesheets_json']); ?>"
+                                data-tejlg-stylesheet-links-html="<?php echo esc_attr(isset($pattern_data['iframe_stylesheet_links_json']) ? $pattern_data['iframe_stylesheet_links_json'] : '""'); ?>"
+                            ><?php echo $pattern_data['iframe_json']; ?></script>
+                        </div>
+                    </div>
 
                 <div class="pattern-controls">
                     <button


### PR DESCRIPTION
## Summary
- add a compact preview layout with an explicit “Prévisualiser” trigger and loading indicator in the import preview
- lazy-load pattern iframe previews via an IntersectionObserver-aware controller that cleans up blob URLs and observers when previews are torn down
- refresh the admin styles to support the compact cards, category chips, and loading state

## Testing
- not run (phpunit/playwright environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df962f8208832ea0f0c90c2c9aa803