### PR TITLE
Add confirmation prompt before theme import submission

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -406,6 +406,19 @@ document.addEventListener('DOMContentLoaded', function() {
         ? localization.themeImportConfirm
         : '';
 
+    if (themeImportConfirmMessage) {
+        const themeImportForm = document.getElementById('tejlg-import-theme-form');
+
+        if (themeImportForm) {
+            themeImportForm.addEventListener('submit', function(event) {
+                if (!window.confirm(themeImportConfirmMessage)) {
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+                }
+            });
+        }
+    }
+
     // Gérer la case "Tout sélectionner" pour l'import
     const selectAllCheckbox = document.getElementById('select-all-patterns');
     if (selectAllCheckbox) {


### PR DESCRIPTION
## Summary
- prompt administrators for confirmation before submitting the theme import form
- prevent the import when the confirmation dialog is canceled to avoid unintended imports

## Testing
- Manual confirmation: canceled import after clicking "Annuler" and verified the import was blocked
- Manual smoke: loaded admin screens without the form and confirmed no console errors occurred

------
https://chatgpt.com/codex/tasks/task_e_68dfc19c8794832e857f4b95a5e4c356