### PR TITLE
Fix import select-all behavior for filtered patterns

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -407,14 +407,6 @@ document.addEventListener('DOMContentLoaded', function() {
         : '';
 
     // Gérer la case "Tout sélectionner" pour l'import
-    const selectAllCheckbox = document.getElementById('select-all-patterns');
-    if (selectAllCheckbox) {
-        selectAllCheckbox.addEventListener('change', function(e) {
-            document.querySelectorAll('input[name="selected_patterns[]"]').forEach(function(checkbox) {
-                checkbox.checked = e.target.checked;
-            });
-        });
-    }
 
     // Gérer l'accordéon sur la page de débogage
     const accordionContainer = document.getElementById('debug-accordion');


### PR DESCRIPTION
## Summary
- remove the standalone `#select-all-patterns` change listener so only the pattern selection controller propagates checkbox state
- add an end-to-end test covering the import preview select-all toggle when items are hidden by search

## Testing
- npx playwright test tests/e2e/pattern-export-select-all.spec.js *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1193/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc1984fb4832ea848fa5689ef88c7