### PR TITLE
Scope select-all toggles to visible pattern items

### DIFF
--- a/tests/e2e/pattern-export-select-all.spec.js
+++ b/tests/e2e/pattern-export-select-all.spec.js
@@ -58,6 +58,24 @@ test.describe('Pattern export selection screen', () => {
     await expect(betaCheckbox).toBeChecked();
     await expect(alphaCheckbox).toBeChecked();
     await expect(gammaCheckbox).not.toBeChecked();
+    await expect(selectAll).toBeChecked();
+    await expect(selectAll).toHaveJSProperty('indeterminate', false);
+
+    await selectAll.uncheck();
+
+    await expect(betaCheckbox).not.toBeChecked();
+    await expect(alphaCheckbox).toBeChecked();
+    await expect(gammaCheckbox).not.toBeChecked();
+    await expect(selectAll).not.toBeChecked();
+    await expect(selectAll).toHaveJSProperty('indeterminate', false);
+
+    await selectAll.check();
+
+    await expect(betaCheckbox).toBeChecked();
+    await expect(alphaCheckbox).toBeChecked();
+    await expect(gammaCheckbox).not.toBeChecked();
+    await expect(selectAll).toBeChecked();
+    await expect(selectAll).toHaveJSProperty('indeterminate', false);
 
     await searchInput.fill('');
 

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -1692,6 +1692,24 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         }
 
+        function getVisibleCheckboxes() {
+            return getVisibleItems()
+                .map(function(item) {
+                    return getItemCheckbox(item);
+                })
+                .filter(function(checkbox) {
+                    return checkbox !== null && !checkbox.disabled;
+                });
+        }
+
+        function applySelectAllStateToVisible(shouldCheck) {
+            getVisibleCheckboxes().forEach(function(checkbox) {
+                if (checkbox.checked !== shouldCheck) {
+                    checkbox.checked = shouldCheck;
+                }
+            });
+        }
+
         function setBusy(isBusy) {
             if (!statusElement) {
                 return;
@@ -1898,14 +1916,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 return;
             }
 
-            const visibleItems = getVisibleItems();
-            const visibleCheckboxes = visibleItems
-                .map(function(item) {
-                    return getItemCheckbox(item);
-                })
-                .filter(function(checkbox) {
-                    return checkbox !== null;
-                });
+            const visibleCheckboxes = getVisibleCheckboxes();
 
             if (!visibleCheckboxes.length) {
                 selectAllCheckbox.checked = false;
@@ -2011,12 +2022,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (selectAllCheckbox) {
             selectAllCheckbox.addEventListener('change', function(event) {
                 const shouldCheck = event.target.checked;
-                getVisibleItems().forEach(function(item) {
-                    const checkbox = getItemCheckbox(item);
-                    if (checkbox) {
-                        checkbox.checked = shouldCheck;
-                    }
-                });
+                applySelectAllStateToVisible(shouldCheck);
 
                 updateSelectAllState();
             });


### PR DESCRIPTION
## Summary
- reuse the pattern selection controller to toggle only the visible checkboxes when select-all changes
- refactor the controller with helpers for visible checkbox handling and rely on them to keep hidden items untouched
- expand the end-to-end regression to assert that hidden export/import items remain unchanged when select-all is toggled repeatedly

## Testing
- npx playwright test tests/e2e/pattern-export-select-all.spec.js *(fails: WordPress REST API not reachable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcc9ba418832ea7cbcad6d371ddf3