### PR TITLE
Add selection count feedback to pattern selection tools

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -179,6 +179,14 @@
     color: #3c434a;
 }
 
+.pattern-selection-count {
+    margin: 0 0 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--tejlg-text-subtle-color);
+}
+
 .pattern-import-items .pattern-item {
     margin-bottom: 20px;
 }

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -103,6 +103,10 @@ class TEJLG_Admin {
                     'filtersSummaryIntro' => esc_html__('Filtres actifs :', 'theme-export-jlg'),
                     'filtersSummaryJoin'  => esc_html__(' ; ', 'theme-export-jlg'),
                 ],
+                'patternSelectionCount' => [
+                    'none' => esc_html__('0 sélection', 'theme-export-jlg'),
+                    'some' => esc_html__('%s sélection(s)', 'theme-export-jlg'),
+                ],
                 'exportAsync' => [
                     'ajaxUrl' => admin_url('admin-ajax.php'),
                     'actions' => [

--- a/theme-export-jlg/templates/admin/export-pattern-selection.php
+++ b/theme-export-jlg/templates/admin/export-pattern-selection.php
@@ -29,6 +29,12 @@ $back_url = add_query_arg([
                 <input type="search" id="pattern-search" placeholder="<?php echo esc_attr__('Rechercher…', 'theme-export-jlg'); ?>" aria-controls="pattern-selection-items">
             </p>
             <p id="pattern-selection-status" aria-live="polite" class="screen-reader-text"></p>
+            <p
+                id="pattern-selection-count"
+                class="pattern-selection-count"
+                aria-live="polite"
+                aria-atomic="true"
+            ></p>
             <ul class="pattern-selection-items" id="pattern-selection-items" aria-live="polite" data-searchable="true">
                 <?php
                 $pattern_counter = $per_page > 0 ? (($current_page - 1) * $per_page) : 0;
@@ -150,6 +156,6 @@ $back_url = add_query_arg([
         </div>
         <p><label><input type="checkbox" name="export_portable" value="1" <?php checked($portable_mode_enabled); ?>> <strong><?php esc_html_e('Générer un export "portable"', 'theme-export-jlg'); ?></strong> <?php esc_html_e('(Recommandé pour migrer vers un autre site)', 'theme-export-jlg'); ?></label></p>
 
-        <p><button type="submit" name="tejlg_export_selected_patterns" class="button button-primary button-hero"><?php esc_html_e('Exporter la sélection', 'theme-export-jlg'); ?></button></p>
+        <p><button type="submit" name="tejlg_export_selected_patterns" class="button button-primary button-hero" data-pattern-submit="true"><?php esc_html_e('Exporter la sélection', 'theme-export-jlg'); ?></button></p>
     </form>
 <?php endif; ?>

--- a/theme-export-jlg/templates/admin/import-preview.php
+++ b/theme-export-jlg/templates/admin/import-preview.php
@@ -110,6 +110,12 @@ $controls_help_id = 'tejlg-import-controls-help';
             </div>
         </div>
         <p id="pattern-import-status" class="pattern-import-status" aria-live="polite" aria-atomic="true"></p>
+        <p
+            id="pattern-import-selection-count"
+            class="pattern-selection-count"
+            aria-live="polite"
+            aria-atomic="true"
+        ></p>
         <div class="pattern-import-items" id="patterns-preview-items" data-searchable="true">
             <?php foreach ($patterns as $pattern_data): ?>
                 <?php
@@ -284,5 +290,5 @@ $controls_help_id = 'tejlg-import-controls-help';
             </details>
         </div>
     <?php endif; ?>
-    <p><button type="submit" name="tejlg_import_patterns_step2" class="button button-primary button-hero"><?php esc_html_e('Importer la sélection', 'theme-export-jlg'); ?></button></p>
+    <p><button type="submit" name="tejlg_import_patterns_step2" class="button button-primary button-hero" data-pattern-submit="true"><?php esc_html_e('Importer la sélection', 'theme-export-jlg'); ?></button></p>
 </form>


### PR DESCRIPTION
## Summary
- add aria-live feedback for selected pattern counts and tag submit buttons for control
- extend the pattern selection controller to track selections, toggle select-all state, and enable or disable targeted submits
- localize the new count messages and add minimal styling for the status display

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff7e9f428832e9a2b55c10edae778