### PR TITLE
Improve accessibility of debug accordion controls

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -381,17 +381,34 @@
 
 /* Style pour l'accordéon de débogage */
 #debug-accordion .accordion-section-title {
+    display: block;
+    width: 100%;
+    text-align: left;
+    border: 0;
     border-bottom: 1px solid var(--tejlg-border-color);
     padding: 15px;
     cursor: pointer;
     font-size: 1.2em;
+    font-weight: 600;
     background: var(--tejlg-surface-alt-color);
+    color: inherit;
     margin: 0;
+    font-family: inherit;
+    line-height: 1.5;
+    appearance: none;
+    -webkit-appearance: none;
+    transition: background-color 0.2s ease-in-out;
 }
 
-#debug-accordion .accordion-section-title:hover {
+#debug-accordion .accordion-section-title:hover,
+#debug-accordion .accordion-section-title:focus-visible {
     background: var(--tejlg-surface-alt-color);
     background: color-mix(in srgb, var(--tejlg-surface-alt-color) 80%, var(--tejlg-surface-muted-color));
+}
+
+#debug-accordion .accordion-section-title:focus-visible {
+    outline: 2px solid var(--tejlg-accent-color);
+    outline-offset: 2px;
 }
 
 #debug-accordion .accordion-section-content {
@@ -400,6 +417,10 @@
     border: 1px solid var(--tejlg-border-color);
     border-top: 0;
     background: var(--tejlg-surface-color);
+}
+
+#debug-accordion .accordion-section-content[hidden] {
+    display: none;
 }
 
 #debug-accordion .accordion-section.open .accordion-section-content {

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -424,12 +424,42 @@ document.addEventListener('DOMContentLoaded', function() {
     // Gérer l'accordéon sur la page de débogage
     const accordionContainer = document.getElementById('debug-accordion');
     if (accordionContainer) {
-        const accordionTitles = accordionContainer.querySelectorAll('.accordion-section-title');
-        accordionTitles.forEach(function(title) {
-            title.addEventListener('click', function() {
-                const parentSection = this.closest('.accordion-section');
-                if (parentSection) {
-                    parentSection.classList.toggle('open');
+        const accordionSections = accordionContainer.querySelectorAll('.accordion-section');
+        const activationKeys = [' ', 'Spacebar', 'Space', 'Enter'];
+
+        accordionSections.forEach(function(section) {
+            const trigger = section.querySelector('.accordion-section-title');
+            const content = section.querySelector('.accordion-section-content');
+
+            if (!trigger || !content) {
+                return;
+            }
+
+            const setExpandedState = function(isExpanded) {
+                trigger.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+                content.hidden = !isExpanded;
+                content.setAttribute('aria-hidden', isExpanded ? 'false' : 'true');
+                section.classList.toggle('open', isExpanded);
+            };
+
+            const initialExpanded = trigger.getAttribute('aria-expanded') === 'true'
+                || section.classList.contains('open')
+                || !content.hasAttribute('hidden');
+            setExpandedState(initialExpanded);
+
+            const toggleSection = function() {
+                const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+                setExpandedState(!isExpanded);
+            };
+
+            trigger.addEventListener('click', function() {
+                toggleSection();
+            });
+
+            trigger.addEventListener('keydown', function(event) {
+                if (activationKeys.includes(event.key)) {
+                    event.preventDefault();
+                    toggleSection();
                 }
             });
         });

--- a/theme-export-jlg/templates/admin/debug.php
+++ b/theme-export-jlg/templates/admin/debug.php
@@ -53,8 +53,23 @@
 <div id="debug-accordion" class="tejlg-card components-card is-elevated">
     <div class="components-card__body">
         <div class="accordion-section">
-            <h3 class="accordion-section-title"><?php esc_html_e('Informations Système & WordPress', 'theme-export-jlg'); ?></h3>
-            <div class="accordion-section-content">
+            <button
+                type="button"
+                class="accordion-section-title"
+                id="debug-accordion-trigger-system"
+                aria-expanded="false"
+                aria-controls="debug-accordion-panel-system"
+            >
+                <?php esc_html_e('Informations Système & WordPress', 'theme-export-jlg'); ?>
+            </button>
+            <div
+                class="accordion-section-content"
+                id="debug-accordion-panel-system"
+                role="region"
+                aria-labelledby="debug-accordion-trigger-system"
+                hidden
+                aria-hidden="true"
+            >
                 <div class="tejlg-table-scroll">
                     <table class="widefat striped">
                         <tbody>
@@ -92,8 +107,23 @@
             </div>
         </div>
         <div class="accordion-section">
-            <h3 class="accordion-section-title"><?php esc_html_e('Compositions personnalisées enregistrées', 'theme-export-jlg'); ?></h3>
-            <div class="accordion-section-content">
+            <button
+                type="button"
+                class="accordion-section-title"
+                id="debug-accordion-trigger-patterns"
+                aria-expanded="false"
+                aria-controls="debug-accordion-panel-patterns"
+            >
+                <?php esc_html_e('Compositions personnalisées enregistrées', 'theme-export-jlg'); ?>
+            </button>
+            <div
+                class="accordion-section-content"
+                id="debug-accordion-panel-patterns"
+                role="region"
+                aria-labelledby="debug-accordion-trigger-patterns"
+                hidden
+                aria-hidden="true"
+            >
             <?php
             $current_user_id = get_current_user_id();
             $custom_patterns_query = new WP_Query(


### PR DESCRIPTION
## Summary
- replace the debug accordion headings with accessible buttons tied to labelled panels
- refresh the admin accordion styles to preserve the previous look while supporting focus states
- update the accordion script to sync aria attributes and handle keyboard activation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff7ea576c832e89fb9c4443dcf22b