### PR TITLE
Add preview width controls to pattern import previews

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -148,6 +148,73 @@
     min-width: 180px;
 }
 
+.pattern-import-control-label {
+    font-weight: 600;
+}
+
+.pattern-import-control--preview-width {
+    min-width: 260px;
+}
+
+.pattern-preview-width-buttons {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.pattern-preview-width-button {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+}
+
+.pattern-preview-width-button.is-active {
+    border-color: var(--tejlg-accent-color);
+    background-color: var(--tejlg-accent-color);
+    color: #fff;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tejlg-accent-color) 25%, transparent);
+}
+
+.pattern-preview-width-button.is-active:focus {
+    box-shadow: inset 0 0 0 1px #fff, 0 0 0 1px var(--tejlg-accent-color);
+}
+
+.pattern-preview-width-custom {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    margin-top: 0.75rem;
+}
+
+.pattern-preview-width-custom-controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(70px, 110px) auto;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.pattern-preview-width-range {
+    width: 100%;
+}
+
+.pattern-preview-width-number {
+    width: 100%;
+    max-width: 110px;
+}
+
+.pattern-preview-width-value {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.pattern-preview-width-description {
+    margin: 0;
+    color: var(--tejlg-text-muted-color);
+}
+
 .pattern-import-control--search {
     flex: 1 1 260px;
     min-width: 220px;
@@ -230,6 +297,19 @@
         width: 100%;
         min-width: 0;
     }
+
+    .pattern-preview-width-buttons {
+        gap: 0.4rem;
+    }
+
+    .pattern-preview-width-custom-controls {
+        grid-template-columns: 1fr;
+        gap: 0.5rem;
+    }
+
+    .pattern-preview-width-number {
+        max-width: none;
+    }
 }
 
 .pattern-selector {
@@ -239,6 +319,7 @@
 }
 
 .pattern-preview-wrapper {
+    --tejlg-preview-max-width: 960px;
     padding: 15px;
     background: var(--tejlg-surface-muted-color);
 }
@@ -326,6 +407,9 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
+    width: 100%;
+    max-width: var(--tejlg-preview-max-width, 960px);
+    margin-inline: auto;
 }
 
 .pattern-preview-trigger--collapse {
@@ -336,6 +420,9 @@
     display: flex;
     gap: 8px;
     align-items: center;
+    width: 100%;
+    max-width: var(--tejlg-preview-max-width, 960px);
+    margin-inline: auto;
 }
 
 .pattern-preview-loading .spinner {
@@ -353,6 +440,15 @@
     height: auto;
     border: 1px dashed var(--tejlg-border-color);
     background: var(--tejlg-surface-color);
+    max-width: var(--tejlg-preview-max-width, 960px);
+    margin-inline: auto;
+    display: block;
+}
+
+.pattern-preview-message {
+    width: 100%;
+    max-width: var(--tejlg-preview-max-width, 960px);
+    margin-inline: auto;
 }
 
 /* Placeholder pour les blocs dynamiques non rendus */

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -581,6 +581,305 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     const previewWrappers = document.querySelectorAll('.pattern-preview-wrapper');
+    const previewControllers = new WeakMap();
+
+    const previewWidthControl = document.querySelector('[data-preview-width-control]');
+    if (previewWidthControl && previewWrappers.length) {
+        const previewWidthStrings = (typeof localization.previewWidth === 'object' && localization.previewWidth !== null)
+            ? localization.previewWidth
+            : {};
+
+        const STORAGE_CHOICE_KEY = 'tejlgPreviewWidthChoice';
+        const STORAGE_CUSTOM_KEY = 'tejlgPreviewWidthCustom';
+        const CUSTOM_MIN_WIDTH = 320;
+        const CUSTOM_MAX_WIDTH = 1600;
+        const DEFAULT_EDITOR_WIDTH = 960;
+        const DEFAULT_CUSTOM_WIDTH = 1024;
+
+        const PRESET_WIDTHS = {
+            editor: DEFAULT_EDITOR_WIDTH,
+            full: null,
+        };
+
+        const widthButtons = previewWidthControl.querySelectorAll('[data-preview-width-option]');
+        const customContainer = previewWidthControl.querySelector('[data-preview-width-custom]');
+        const customRange = previewWidthControl.querySelector('[data-preview-width-range]');
+        const customNumber = previewWidthControl.querySelector('[data-preview-width-number]');
+        const valueDisplay = previewWidthControl.querySelector('[data-preview-width-value]');
+        const customButton = previewWidthControl.querySelector('[data-preview-width-option="custom"]');
+
+        const clampToCustomRange = function(value) {
+            if (typeof value !== 'number' || Number.isNaN(value)) {
+                return DEFAULT_CUSTOM_WIDTH;
+            }
+
+            if (value < CUSTOM_MIN_WIDTH) {
+                return CUSTOM_MIN_WIDTH;
+            }
+
+            if (value > CUSTOM_MAX_WIDTH) {
+                return CUSTOM_MAX_WIDTH;
+            }
+
+            return value;
+        };
+
+        const normalizeWidthValue = function(value, fallback) {
+            if (typeof value === 'number' && !Number.isNaN(value)) {
+                return clampToCustomRange(value);
+            }
+
+            const parsed = parseInt(value, 10);
+
+            if (Number.isNaN(parsed)) {
+                const fallbackValue = typeof fallback === 'number' ? fallback : DEFAULT_CUSTOM_WIDTH;
+                return clampToCustomRange(fallbackValue);
+            }
+
+            return clampToCustomRange(parsed);
+        };
+
+        const parseChoice = function(choice) {
+            if (choice === 'full' || choice === 'custom' || choice === 'editor') {
+                return choice;
+            }
+
+            return 'editor';
+        };
+
+        const storage = {
+            get: function(key) {
+                try {
+                    return window.localStorage.getItem(key);
+                } catch (error) {
+                    return null;
+                }
+            },
+            set: function(key, value) {
+                try {
+                    window.localStorage.setItem(key, value);
+                } catch (error) {
+                    // Ignore storage write errors (e.g. private browsing).
+                }
+            },
+        };
+
+        let valueTemplate = '';
+        if (typeof previewWidthStrings.valueTemplate === 'string' && previewWidthStrings.valueTemplate.length) {
+            valueTemplate = previewWidthStrings.valueTemplate;
+        } else if (valueDisplay && typeof valueDisplay.dataset.valueTemplate === 'string' && valueDisplay.dataset.valueTemplate.length) {
+            valueTemplate = valueDisplay.dataset.valueTemplate;
+        } else {
+            valueTemplate = 'Largeur : %s px';
+        }
+
+        const valueUnit = (typeof previewWidthStrings.unit === 'string' && previewWidthStrings.unit.length)
+            ? previewWidthStrings.unit
+            : 'px';
+
+        if (valueDisplay) {
+            valueDisplay.dataset.valueTemplate = valueTemplate;
+        }
+
+        const formatWidthLabel = function(width) {
+            if (typeof valueTemplate === 'string' && valueTemplate.indexOf('%s') !== -1) {
+                return valueTemplate.replace('%s', width);
+            }
+
+            return width + ' ' + valueUnit;
+        };
+
+        const customInputLabel = (typeof previewWidthStrings.customInputLabel === 'string' && previewWidthStrings.customInputLabel.length)
+            ? previewWidthStrings.customInputLabel
+            : '';
+
+        if (customRange && customInputLabel) {
+            customRange.setAttribute('aria-label', customInputLabel);
+        }
+
+        if (customNumber && customInputLabel) {
+            customNumber.setAttribute('aria-label', customInputLabel);
+        }
+
+        const updateCustomInputs = function(width) {
+            const sanitized = clampToCustomRange(width);
+            const widthString = String(sanitized);
+
+            if (customRange && customRange.value !== widthString) {
+                customRange.value = widthString;
+            }
+
+            if (customNumber && customNumber.value !== widthString) {
+                customNumber.value = widthString;
+            }
+
+            if (valueDisplay) {
+                valueDisplay.textContent = formatWidthLabel(sanitized);
+            }
+
+            return sanitized;
+        };
+
+        const updateActiveButton = function(choice) {
+            Array.prototype.forEach.call(widthButtons, function(button) {
+                const option = button.getAttribute('data-preview-width-option');
+                const isActive = option === choice;
+
+                if (isActive) {
+                    button.classList.add('is-active');
+                } else {
+                    button.classList.remove('is-active');
+                }
+
+                button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+
+                if (option === 'custom') {
+                    button.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+                }
+            });
+        };
+
+        const toggleCustomVisibility = function(choice) {
+            if (!customContainer) {
+                return;
+            }
+
+            const isCustom = choice === 'custom';
+            customContainer.hidden = !isCustom;
+            previewWidthControl.classList.toggle('is-custom-width-active', isCustom);
+
+            if (customButton) {
+                customButton.setAttribute('aria-expanded', isCustom ? 'true' : 'false');
+            }
+        };
+
+        const forEachWrapper = function(callback) {
+            Array.prototype.forEach.call(previewWrappers, function(wrapper, index) {
+                if (typeof callback === 'function') {
+                    callback(wrapper, index);
+                }
+            });
+        };
+
+        const applyWidthChoice = function(choice, options) {
+            const shouldSaveChoice = !options || options.saveChoice !== false;
+            const resolvedChoice = parseChoice(choice);
+            let cssValue = '';
+
+            if (resolvedChoice === 'full') {
+                cssValue = 'none';
+            } else if (resolvedChoice === 'custom') {
+                cssValue = clampToCustomRange(currentCustomWidth) + 'px';
+            } else {
+                const presetValue = PRESET_WIDTHS[resolvedChoice];
+                if (typeof presetValue === 'number') {
+                    cssValue = presetValue + 'px';
+                }
+            }
+
+            previewWidthControl.setAttribute('data-preview-width-active', resolvedChoice);
+
+            forEachWrapper(function(wrapper) {
+                if (!wrapper) {
+                    return;
+                }
+
+                wrapper.setAttribute('data-preview-width', resolvedChoice);
+
+                if (cssValue === 'none') {
+                    wrapper.style.setProperty('--tejlg-preview-max-width', 'none');
+                } else if (cssValue) {
+                    wrapper.style.setProperty('--tejlg-preview-max-width', cssValue);
+                } else {
+                    wrapper.style.removeProperty('--tejlg-preview-max-width');
+                }
+            });
+
+            forEachWrapper(function(wrapper) {
+                const controller = previewControllers.get(wrapper);
+                if (controller && typeof controller.syncHeight === 'function') {
+                    controller.syncHeight();
+                }
+            });
+
+            if (shouldSaveChoice) {
+                storage.set(STORAGE_CHOICE_KEY, resolvedChoice);
+            }
+        };
+
+        const commitCustomWidth = function(value, options) {
+            const sanitized = normalizeWidthValue(value, currentCustomWidth);
+            currentCustomWidth = sanitized;
+            updateCustomInputs(sanitized);
+
+            if (!options || options.save !== false) {
+                storage.set(STORAGE_CUSTOM_KEY, String(sanitized));
+            }
+
+            if (currentChoice === 'custom') {
+                applyWidthChoice('custom', { saveChoice: false });
+            }
+        };
+
+        let currentChoice = parseChoice(storage.get(STORAGE_CHOICE_KEY));
+        let currentCustomWidth = normalizeWidthValue(storage.get(STORAGE_CUSTOM_KEY), DEFAULT_CUSTOM_WIDTH);
+
+        currentCustomWidth = updateCustomInputs(currentCustomWidth);
+        updateActiveButton(currentChoice);
+        toggleCustomVisibility(currentChoice);
+        applyWidthChoice(currentChoice, { saveChoice: false });
+
+        Array.prototype.forEach.call(widthButtons, function(button) {
+            button.addEventListener('click', function() {
+                const option = parseChoice(button.getAttribute('data-preview-width-option'));
+                currentChoice = option;
+                updateActiveButton(option);
+                toggleCustomVisibility(option);
+                applyWidthChoice(option);
+            });
+        });
+
+        if (customRange) {
+            customRange.addEventListener('input', function() {
+                commitCustomWidth(customRange.value);
+            });
+        }
+
+        if (customNumber) {
+            customNumber.addEventListener('input', function() {
+                if (customNumber.value === '') {
+                    return;
+                }
+
+                commitCustomWidth(customNumber.value);
+            });
+
+            customNumber.addEventListener('blur', function() {
+                if (customNumber.value === '') {
+                    updateCustomInputs(currentCustomWidth);
+                    return;
+                }
+
+                commitCustomWidth(customNumber.value);
+            });
+
+            customNumber.addEventListener('keydown', function(event) {
+                if (event.key === 'Enter') {
+                    if (customNumber.value === '') {
+                        updateCustomInputs(currentCustomWidth);
+                        return;
+                    }
+
+                    commitCustomWidth(customNumber.value);
+                }
+            });
+        }
+
+        previewWidthControl.addEventListener('tejlg:refresh-preview-width', function() {
+            applyWidthChoice(currentChoice, { saveChoice: false });
+        });
+    }
+
     if (previewWrappers.length) {
         const blobSupported = typeof URL !== 'undefined' && URL !== null && typeof URL.createObjectURL === 'function';
         const activeBlobUrls = new Set();
@@ -1385,6 +1684,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 requestLoad: requestLoad,
                 collapse: collapsePreview,
                 onIntersection: onIntersection,
+                syncHeight: function() {
+                    if (state.previewInitialized) {
+                        scheduleHeightSync();
+                    }
+                },
                 destroy: function() {
                     if (patternItem) {
                         patternItem.removeEventListener('tejlg:request-preview', onPreviewRequest);
@@ -1408,6 +1712,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 intersectionObserver.observe(wrapper);
             }
         });
+
+        if (previewWidthControl) {
+            try {
+                previewWidthControl.dispatchEvent(new CustomEvent('tejlg:refresh-preview-width'));
+            } catch (error) {
+                const event = document.createEvent('CustomEvent');
+                event.initCustomEvent('tejlg:refresh-preview-width', false, false, {});
+                previewWidthControl.dispatchEvent(event);
+            }
+        }
     }
     // Gérer la sélection, la recherche et les filtres pour l'export et l'import de compositions
     const patternSelectionStatusStrings = (typeof localization.patternSelectionStatus === 'object' && localization.patternSelectionStatus !== null)

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -107,6 +107,11 @@ class TEJLG_Admin {
                     'none' => esc_html__('0 sélection', 'theme-export-jlg'),
                     'some' => esc_html__('%s sélection(s)', 'theme-export-jlg'),
                 ],
+                'previewWidth' => [
+                    'valueTemplate'    => esc_html__('Largeur : %s px', 'theme-export-jlg'),
+                    'unit'             => esc_html__('px', 'theme-export-jlg'),
+                    'customInputLabel' => esc_html__('Largeur personnalisée (px)', 'theme-export-jlg'),
+                ],
                 'exportAsync' => [
                     'ajaxUrl' => admin_url('admin-ajax.php'),
                     'actions' => [

--- a/theme-export-jlg/templates/admin/import-preview.php
+++ b/theme-export-jlg/templates/admin/import-preview.php
@@ -108,6 +108,83 @@ $controls_help_id = 'tejlg-import-controls-help';
                     <option value="original" <?php selected($default_sort, 'original'); ?>><?php esc_html_e('Ordre du fichier importé', 'theme-export-jlg'); ?></option>
                 </select>
             </div>
+            <div
+                class="pattern-import-control pattern-import-control--preview-width"
+                data-preview-width-control
+            >
+                <span class="pattern-import-control-label"><?php esc_html_e('Largeur de la prévisualisation', 'theme-export-jlg'); ?></span>
+                <div class="pattern-preview-width-buttons" role="group" aria-label="<?php esc_attr_e('Options de largeur de prévisualisation', 'theme-export-jlg'); ?>">
+                    <button
+                        type="button"
+                        class="button button-secondary pattern-preview-width-button"
+                        data-preview-width-option="editor"
+                        data-preview-width
+                        aria-pressed="false"
+                    >
+                        <?php esc_html_e('Éditeur', 'theme-export-jlg'); ?>
+                    </button>
+                    <button
+                        type="button"
+                        class="button button-secondary pattern-preview-width-button"
+                        data-preview-width-option="full"
+                        data-preview-width
+                        aria-pressed="false"
+                    >
+                        <?php esc_html_e('Pleine largeur', 'theme-export-jlg'); ?>
+                    </button>
+                    <button
+                        type="button"
+                        class="button button-secondary pattern-preview-width-button"
+                        data-preview-width-option="custom"
+                        data-preview-width
+                        aria-pressed="false"
+                        aria-controls="tejlg-preview-width-custom-panel"
+                        aria-expanded="false"
+                    >
+                        <?php esc_html_e('Largeur personnalisée…', 'theme-export-jlg'); ?>
+                    </button>
+                </div>
+                <div
+                    class="pattern-preview-width-custom"
+                    id="tejlg-preview-width-custom-panel"
+                    data-preview-width-custom
+                    hidden
+                >
+                    <span class="pattern-preview-width-custom-label" id="tejlg-preview-width-custom-label"><?php esc_html_e('Largeur personnalisée (px)', 'theme-export-jlg'); ?></span>
+                    <div class="pattern-preview-width-custom-controls" role="group" aria-labelledby="tejlg-preview-width-custom-label">
+                        <input
+                            type="range"
+                            id="tejlg-preview-width-range"
+                            class="pattern-preview-width-range"
+                            min="320"
+                            max="1600"
+                            step="10"
+                            value="1024"
+                            data-preview-width-range
+                            aria-label="<?php esc_attr_e('Définir la largeur personnalisée en pixels', 'theme-export-jlg'); ?>"
+                        >
+                        <label class="screen-reader-text" for="tejlg-preview-width-number"><?php esc_html_e('Définir la largeur personnalisée en pixels', 'theme-export-jlg'); ?></label>
+                        <input
+                            type="number"
+                            id="tejlg-preview-width-number"
+                            class="pattern-preview-width-number"
+                            min="320"
+                            max="1600"
+                            step="10"
+                            value="1024"
+                            data-preview-width-number
+                        >
+                        <output
+                            class="pattern-preview-width-value"
+                            for="tejlg-preview-width-range tejlg-preview-width-number"
+                            data-preview-width-value
+                            data-value-template="<?php echo esc_attr__('Largeur : %s px', 'theme-export-jlg'); ?>"
+                            aria-live="polite"
+                        ><?php echo esc_html__('Largeur : 1024 px', 'theme-export-jlg'); ?></output>
+                    </div>
+                    <p class="description pattern-preview-width-description"><?php esc_html_e('Ajustez la largeur pour simuler différents écrans.', 'theme-export-jlg'); ?></p>
+                </div>
+            </div>
         </div>
         <p id="pattern-import-status" class="pattern-import-status" aria-live="polite" aria-atomic="true"></p>
         <p


### PR DESCRIPTION
## Summary
- add preview width controls with preset buttons and a custom slider to the pattern import toolbar
- synchronize preview iframe widths, persist user preference, and keep auto-height in sync when width changes
- style the new controls, apply responsive max-width handling, and localize related strings

## Testing
- php -l theme-export-jlg/templates/admin/import-preview.php
- php -l theme-export-jlg/includes/class-tejlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68e03aa178a8832e896d7774df58e910