### PR TITLE
Ensure PclZip fallback includes root directory in exports

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-zip-writer.php
+++ b/theme-export-jlg/includes/class-tejlg-zip-writer.php
@@ -110,8 +110,9 @@ class TEJLG_Zip_Writer {
         // by creating a directory entry with no contents.
         $result = $this->zip->add([
             [
-                PCLZIP_ATT_FILE_NAME    => $directory_path,
-                PCLZIP_ATT_FILE_CONTENT => '',
+                PCLZIP_ATT_FILE_NAME          => $directory_path,
+                PCLZIP_ATT_FILE_NEW_FULL_NAME => $directory_path,
+                PCLZIP_ATT_FILE_CONTENT       => '',
             ],
         ]);
 


### PR DESCRIPTION
## Summary
- ensure the PclZip fallback writes directory entries with an explicit stored filename so the archive mirrors ZipArchive output
- extend the export fallback test to inspect the generated archive and confirm the theme root directory is present

## Testing
- npm run test:php *(fails: phpunit not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ee9ea298832e9194366f39c11fff