### PR TITLE
Handle explicit theme overwrite confirmation

### DIFF
--- a/tests/test-import-theme.php
+++ b/tests/test-import-theme.php
@@ -56,7 +56,7 @@ class Test_Import_Theme extends WP_UnitTestCase {
         }
     }
 
-    public function test_import_theme_requires_confirmation_before_overwriting_existing_theme() {
+    public function test_finalize_theme_install_result_requires_confirmation_before_overwriting_existing_theme() {
         $error = new WP_Error('folder_exists', 'Destination folder already exists.');
 
         TEJLG_Import::finalize_theme_install_result($error, false);
@@ -72,7 +72,7 @@ class Test_Import_Theme extends WP_UnitTestCase {
         );
     }
 
-    public function test_import_theme_reports_success_when_overwrite_allowed() {
+    public function test_finalize_theme_install_result_reports_success_when_overwrite_allowed() {
         TEJLG_Import::finalize_theme_install_result(true, true);
 
         $messages = get_settings_errors('tejlg_import_messages');
@@ -82,6 +82,22 @@ class Test_Import_Theme extends WP_UnitTestCase {
         $this->assertSame('success', $messages[0]['type']);
         $this->assertStringContainsString(
             "Le thème a été installé avec succès !",
+            $messages[0]['message']
+        );
+    }
+
+    public function test_finalize_theme_install_result_does_not_request_confirmation_when_overwrite_allowed_but_install_fails() {
+        $error = new WP_Error('folder_exists', 'Destination folder already exists.');
+
+        TEJLG_Import::finalize_theme_install_result($error, true);
+
+        $messages = get_settings_errors('tejlg_import_messages');
+
+        $this->assertNotEmpty($messages);
+        $this->assertSame('theme_import_status', $messages[0]['code']);
+        $this->assertSame('error', $messages[0]['type']);
+        $this->assertStringNotContainsString(
+            "Veuillez relancer l'import en confirmant le remplacement explicite.",
             $messages[0]['message']
         );
     }

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -412,6 +412,10 @@ document.addEventListener('DOMContentLoaded', function() {
         if (themeImportForm) {
             const overwriteField = themeImportForm.querySelector('#tejlg_confirm_theme_overwrite');
 
+            if (overwriteField) {
+                overwriteField.value = '0';
+            }
+
             themeImportForm.addEventListener('submit', function(event) {
                 if (!window.confirm(themeImportConfirmMessage)) {
                     if (overwriteField) {

--- a/theme-export-jlg/includes/class-tejlg-admin-import-page.php
+++ b/theme-export-jlg/includes/class-tejlg-admin-import-page.php
@@ -557,7 +557,8 @@ class TEJLG_Admin_Import_Page extends TEJLG_Admin_Page {
 
         if ((int) $theme_file['error'] === UPLOAD_ERR_OK) {
             $allow_overwrite = isset($_POST['tejlg_confirm_theme_overwrite'])
-                && '1' === (string) $_POST['tejlg_confirm_theme_overwrite'];
+                ? wp_validate_boolean(wp_unslash($_POST['tejlg_confirm_theme_overwrite']))
+                : false;
 
             TEJLG_Import::import_theme($theme_file, $allow_overwrite);
             return;

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -116,6 +116,14 @@ class TEJLG_Import {
         ];
     }
 
+    /**
+     * Importe un thème WordPress à partir d'un fichier ZIP téléchargé.
+     *
+     * @param array $file            Tableau de données de téléchargement de fichier.
+     * @param bool  $allow_overwrite Indique si l'écrasement explicite est autorisé.
+     *
+     * @return void
+     */
     public static function import_theme($file, $allow_overwrite = false) {
         if (!current_user_can('install_themes')) {
             if (isset($file['tmp_name'])) {

--- a/theme-export-jlg/templates/admin/import.php
+++ b/theme-export-jlg/templates/admin/import.php
@@ -17,7 +17,7 @@ $import_tab_url = add_query_arg([
             <p><?php echo wp_kses_post(sprintf(__('Téléversez une archive %s d\'un thème. Le plugin l\'installera (capacité WordPress « Installer des thèmes » requise). <strong>Attention :</strong> Un thème existant sera remplacé.', 'theme-export-jlg'), $theme_file_info['code'])); ?></p>
             <form id="tejlg-import-theme-form" method="post" action="<?php echo esc_url($import_tab_url); ?>" enctype="multipart/form-data">
                 <?php wp_nonce_field('tejlg_import_theme_action', 'tejlg_import_theme_nonce'); ?>
-                <input type="hidden" name="tejlg_confirm_theme_overwrite" id="tejlg_confirm_theme_overwrite" value="0">
+                <input type="hidden" name="tejlg_confirm_theme_overwrite" id="tejlg_confirm_theme_overwrite" value="<?php echo esc_attr('0'); ?>">
                 <p><label for="theme_zip"><?php echo esc_html(sprintf(__('Fichier du thème (%s) :', 'theme-export-jlg'), $theme_file_info['display'])); ?></label><br><input type="file" id="theme_zip" name="theme_zip" accept="<?php echo esc_attr($theme_file_info['accept']); ?>" required></p>
                 <p><button type="submit" name="tejlg_import_theme" class="button button-primary wp-ui-primary"><?php esc_html_e('Importer le Thème', 'theme-export-jlg'); ?></button></p>
             </form>


### PR DESCRIPTION
## Summary
- ensure the import form posts an explicit overwrite confirmation flag and initialise/reset it in admin JS
- pass the sanitised overwrite flag from the admin handler into `TEJLG_Import::import_theme()` and document the new parameter
- extend the theme import tests to cover confirmation-required failures and success when the overwrite flag is present

## Testing
- npm test -- --filter=import-theme *(fails: phpunit is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ee9d7438832e8d739a5c247b2c42