### PR TITLE
Add cancellation flow for async theme export jobs

### DIFF
--- a/tests/test-ajax-theme-export.php
+++ b/tests/test-ajax-theme-export.php
@@ -70,4 +70,114 @@ class Test_Ajax_Theme_Export extends WP_Ajax_UnitTestCase {
 
         $_POST = $original_post;
     }
+
+    public function test_cancel_theme_export_cleans_job_and_queue() {
+        $user_id = self::factory()->user->create([
+            'role' => 'administrator',
+        ]);
+
+        wp_set_current_user($user_id);
+
+        $job_id   = 'tejlg_test_job';
+        $temp_zip = wp_tempnam('tejlg-cancel-test');
+
+        $this->assertNotFalse($temp_zip, 'Le fichier temporaire doit être créé.');
+
+        file_put_contents($temp_zip, 'export');
+
+        $job = [
+            'id'              => $job_id,
+            'status'          => 'processing',
+            'progress'        => 50,
+            'processed_items' => 5,
+            'total_items'     => 10,
+            'zip_path'        => $temp_zip,
+            'zip_file_name'   => 'test.zip',
+            'directories_added' => [],
+            'created_at'      => time() - 10,
+            'updated_at'      => time() - 5,
+        ];
+
+        TEJLG_Export::persist_job($job);
+
+        update_user_meta($user_id, '_tejlg_last_theme_export_job_id', $job_id);
+
+        $queue_option = 'wp_background_process_tejlg_theme_export_queue';
+
+        update_option($queue_option, [
+            [
+                [
+                    'job_id'               => $job_id,
+                    'type'                 => 'file',
+                    'real_path'            => $temp_zip,
+                    'relative_path_in_zip' => 'theme/file.php',
+                ],
+            ],
+        ], false);
+
+        wp_schedule_single_event(time() + 60, 'wp_background_process_tejlg_theme_export_cron');
+        set_transient('wp_background_process_tejlg_theme_export_process_lock', microtime(), MINUTE_IN_SECONDS);
+
+        $original_post = $_POST;
+
+        $_POST = [
+            'nonce'  => wp_create_nonce('tejlg_cancel_theme_export'),
+            'job_id' => $job_id,
+        ];
+
+        try {
+            $this->_handleAjax('tejlg_cancel_theme_export');
+        } catch (WPAjaxDieContinueException $exception) {
+            // Attendu pour les appels AJAX en test.
+        }
+
+        $_POST = $original_post;
+
+        $this->assertNotEmpty($this->_last_response, 'La réponse AJAX ne doit pas être vide.');
+
+        $response = json_decode($this->_last_response, true);
+
+        $this->assertIsArray($response, 'La réponse doit être un tableau.');
+        $this->assertArrayHasKey('success', $response);
+        $this->assertTrue($response['success'], 'La requête d\'annulation doit réussir.');
+
+        $this->assertArrayHasKey('data', $response);
+        $this->assertArrayHasKey('job', $response['data']);
+
+        $job_payload = $response['data']['job'];
+        $this->assertIsArray($job_payload, 'Le payload du job doit être un tableau.');
+        $this->assertSame('cancelled', $job_payload['status'], 'Le statut retourné doit indiquer une annulation.');
+
+        $stored_job = TEJLG_Export::get_job($job_id);
+        $this->assertIsArray($stored_job, 'La tâche doit rester persistée.');
+        $this->assertSame('cancelled', $stored_job['status'], 'Le statut de la tâche doit être « cancelled ».');
+        $this->assertSame(0, $stored_job['progress'], 'La progression doit être réinitialisée.');
+        $this->assertSame(
+            esc_html__('Export annulé.', 'theme-export-jlg'),
+            $stored_job['message'],
+            'Le message du job doit indiquer une annulation.'
+        );
+
+        $this->assertFalse(file_exists($temp_zip), 'Le fichier temporaire doit être supprimé.');
+
+        $this->assertEmpty(get_option($queue_option, []), 'La file doit être vidée.');
+
+        $this->assertFalse(
+            wp_next_scheduled('wp_background_process_tejlg_theme_export_cron'),
+            'L\'évènement planifié doit être déprogrammé.'
+        );
+
+        $this->assertFalse(
+            get_transient('wp_background_process_tejlg_theme_export_process_lock'),
+            'Le verrou du processus doit être supprimé.'
+        );
+
+        $this->assertSame(
+            '',
+            get_user_meta($user_id, '_tejlg_last_theme_export_job_id', true),
+            'La référence utilisateur doit être nettoyée.'
+        );
+
+        TEJLG_Export::delete_job($job_id);
+    }
 }

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -118,10 +118,12 @@ class TEJLG_Admin {
                         'start'    => 'tejlg_start_theme_export',
                         'status'   => 'tejlg_theme_export_status',
                         'download' => 'tejlg_download_theme_export',
+                        'cancel'   => 'tejlg_cancel_theme_export',
                     ],
                     'nonces' => [
-                        'start'  => wp_create_nonce('tejlg_start_theme_export'),
-                        'status' => wp_create_nonce('tejlg_theme_export_status'),
+                        'start'   => wp_create_nonce('tejlg_start_theme_export'),
+                        'status'  => wp_create_nonce('tejlg_theme_export_status'),
+                        'cancel'  => wp_create_nonce('tejlg_cancel_theme_export'),
                     ],
                     'pollInterval' => 4000,
                     'strings' => [
@@ -134,6 +136,9 @@ class TEJLG_Admin {
                         'downloadLabel'   => esc_html__("Télécharger l'archive ZIP", 'theme-export-jlg'),
                         'unknownError'    => esc_html__('Une erreur inattendue est survenue.', 'theme-export-jlg'),
                         'statusLabel'     => esc_html__('Statut de la tâche : %1$s', 'theme-export-jlg'),
+                        'cancelled'       => esc_html__('Export annulé.', 'theme-export-jlg'),
+                        'cancelling'      => esc_html__('Annulation…', 'theme-export-jlg'),
+                        'cancelFailed'    => esc_html__("Impossible d'annuler l'export.", 'theme-export-jlg'),
                     ],
                     'previousJob' => TEJLG_Export::get_current_user_job_snapshot(),
                     'defaults'    => [

--- a/theme-export-jlg/includes/class-tejlg-export-process.php
+++ b/theme-export-jlg/includes/class-tejlg-export-process.php
@@ -39,6 +39,10 @@ class TEJLG_Export_Process extends WP_Background_Process {
             return false;
         }
 
+        if ('cancelled' === $job['status']) {
+            return false;
+        }
+
         $type               = isset($item['type']) ? $item['type'] : '';
         $real_path          = isset($item['real_path']) ? (string) $item['real_path'] : '';
         $relative_path_in_zip = isset($item['relative_path_in_zip']) ? (string) $item['relative_path_in_zip'] : '';

--- a/theme-export-jlg/includes/class-wp-background-process.php
+++ b/theme-export-jlg/includes/class-wp-background-process.php
@@ -311,6 +311,19 @@ abstract class WP_Background_Process {
     }
 
     /**
+     * Cancel the background process and clear any queued items.
+     */
+    public function cancel_process() {
+        $this->data        = [];
+        $this->queue_saved = true;
+
+        delete_option($this->queue_key);
+
+        $this->clear_scheduled_event();
+        $this->unlock_process();
+    }
+
+    /**
      * Task to perform on each queue item.
      *
      * @param mixed $item Queue item.

--- a/theme-export-jlg/templates/admin/export.php
+++ b/theme-export-jlg/templates/admin/export.php
@@ -59,6 +59,7 @@ $select_patterns_url = add_query_arg([
                         data-export-progress-bar
                     ></progress>
                     <p class="description" data-export-message></p>
+                    <p><button type="button" class="button button-secondary wp-ui-secondary" data-export-cancel hidden><?php esc_html_e("Annuler l'export", 'theme-export-jlg'); ?></button></p>
                     <p><a href="#" class="button button-secondary wp-ui-secondary" data-export-download hidden target="_blank" rel="noopener"><?php esc_html_e("Télécharger l'archive ZIP", 'theme-export-jlg'); ?></a></p>
                 </div>
             </form>

--- a/theme-export-jlg/theme-export-jlg.php
+++ b/theme-export-jlg/theme-export-jlg.php
@@ -51,6 +51,7 @@ function tejlg_load_textdomain() {
 add_action('wp_ajax_tejlg_start_theme_export', ['TEJLG_Export', 'ajax_start_theme_export']);
 add_action('wp_ajax_tejlg_theme_export_status', ['TEJLG_Export', 'ajax_get_theme_export_status']);
 add_action('wp_ajax_tejlg_download_theme_export', ['TEJLG_Export', 'ajax_download_theme_export']);
+add_action('wp_ajax_tejlg_cancel_theme_export', ['TEJLG_Export', 'ajax_cancel_theme_export']);
 add_action('admin_init', ['TEJLG_Export', 'cleanup_stale_jobs']);
 add_action( 'plugins_loaded', 'tejlg_load_textdomain' );
 add_action( 'plugins_loaded', 'tejlg_run_plugin' );


### PR DESCRIPTION
## Summary
- add a cancel button to the export feedback UI and surface new cancel strings/actions to the admin script localization
- implement client-side handling for cancelling exports, including status updates and spinner control
- expose a new AJAX endpoint that marks jobs as cancelled, clears queues, and ensures background processes and user metadata are cleaned up
- update the background process/task logic and add PHPUnit coverage for the cancellation flow

## Testing
- `npm run test:php` *(fails: phpunit is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e136c34a60832e8b0cd7b918bcd6f3