### PR TITLE
Add export history logging and display

### DIFF
--- a/tests/test-export-history.php
+++ b/tests/test-export-history.php
@@ -1,0 +1,124 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export-history.php';
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-admin-export-page.php';
+
+class Test_Export_History extends WP_UnitTestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        TEJLG_Export_History::clear_history();
+    }
+
+    protected function tearDown(): void {
+        TEJLG_Export_History::clear_history();
+        parent::tearDown();
+    }
+
+    public function test_record_job_persists_summary() {
+        $temp_file = wp_tempnam('history-test.zip');
+        $this->assertNotFalse($temp_file, 'Temporary file should be created.');
+
+        file_put_contents($temp_file, 'demo');
+
+        $job = [
+            'id'              => 'history-job-1',
+            'status'          => 'completed',
+            'zip_path'        => $temp_file,
+            'zip_file_name'   => 'history-job-1.zip',
+            'zip_file_size'   => filesize($temp_file),
+            'exclusions'      => ['node_modules', '*.log'],
+            'created_at'      => time() - 10,
+            'updated_at'      => time() - 5,
+            'completed_at'    => time(),
+            'created_by'      => 123,
+            'created_by_name' => 'History Tester',
+            'created_via'     => 'test',
+        ];
+
+        TEJLG_Export_History::record_job($job, ['origin' => 'unit-test']);
+
+        $history = TEJLG_Export_History::get_entries([
+            'per_page' => 5,
+            'paged'    => 1,
+        ]);
+
+        $this->assertNotEmpty($history['entries'], 'History should contain the recorded job.');
+        $entry = $history['entries'][0];
+
+        $this->assertSame('history-job-1', $entry['job_id']);
+        $this->assertSame('History Tester', $entry['user_name']);
+        $this->assertSame(['node_modules', '*.log'], $entry['exclusions']);
+        $this->assertSame(filesize($temp_file), $entry['zip_file_size']);
+
+        global $wpdb;
+        $autoload = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s",
+                TEJLG_Export_History::OPTION_NAME
+            )
+        );
+
+        $this->assertSame('no', $autoload, 'History option should not be autoloaded.');
+    }
+
+    public function test_history_survives_job_deletion_and_renders_in_admin_template() {
+        $user_id = self::factory()->user->create([
+            'role'         => 'administrator',
+            'display_name' => 'History User',
+        ]);
+
+        wp_set_current_user($user_id);
+
+        $temp_file = wp_tempnam('history-job.zip');
+        $this->assertNotFalse($temp_file, 'Temporary file should be created.');
+
+        file_put_contents($temp_file, str_repeat('a', 1024));
+
+        $job_id = 'history-job-2';
+        $job = [
+            'id'              => $job_id,
+            'status'          => 'completed',
+            'zip_path'        => $temp_file,
+            'zip_file_name'   => 'history-job-2.zip',
+            'zip_file_size'   => filesize($temp_file),
+            'exclusions'      => ['vendor'],
+            'created_at'      => time() - 20,
+            'updated_at'      => time() - 10,
+            'completed_at'    => time() - 5,
+            'created_by'      => $user_id,
+            'created_by_name' => 'History User',
+            'created_via'     => 'admin',
+        ];
+
+        TEJLG_Export::persist_job($job);
+
+        $this->assertFileExists($temp_file, 'Temporary export file should exist before deletion.');
+
+        TEJLG_Export::delete_job($job_id, ['origin' => 'unit-test']);
+
+        $this->assertFileDoesNotExist($temp_file, 'Temporary export file should be deleted by delete_job.');
+
+        $history = TEJLG_Export_History::get_entries([
+            'per_page' => 5,
+            'paged'    => 1,
+        ]);
+
+        $this->assertNotEmpty($history['entries'], 'History should contain the deleted job.');
+        $this->assertSame($job_id, $history['entries'][0]['job_id']);
+
+        $template_dir = dirname(__DIR__) . '/theme-export-jlg/templates/admin/';
+        $export_page  = new TEJLG_Admin_Export_Page($template_dir, 'theme-export-jlg');
+
+        ob_start();
+        $export_page->render();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Historique des exports', $output);
+        $this->assertStringContainsString('history-job-2.zip', $output);
+        $this->assertStringContainsString('History User', $output);
+        $this->assertStringContainsString('vendor', $output);
+
+        wp_set_current_user(0);
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-export-history.php
+++ b/theme-export-jlg/includes/class-tejlg-export-history.php
@@ -1,0 +1,278 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class TEJLG_Export_History {
+    const OPTION_NAME = 'tejlg_export_history_entries';
+
+    public static function record_job($job, array $context = []) {
+        if (!is_array($job) || empty($job['id'])) {
+            return;
+        }
+
+        $entry = self::build_entry_from_job($job, $context);
+
+        if (null === $entry) {
+            return;
+        }
+
+        $entries = self::get_raw_entries();
+
+        $entries = array_values(
+            array_filter(
+                $entries,
+                static function ($existing) use ($entry) {
+                    if (!is_array($existing) || empty($existing['job_id'])) {
+                        return false;
+                    }
+
+                    return (string) $existing['job_id'] !== $entry['job_id'];
+                }
+            )
+        );
+
+        array_unshift($entries, $entry);
+
+        $max_entries = apply_filters('tejlg_export_history_max_entries', 100);
+        $max_entries = is_numeric($max_entries) ? (int) $max_entries : 100;
+
+        if ($max_entries > 0 && count($entries) > $max_entries) {
+            $entries = array_slice($entries, 0, $max_entries);
+        }
+
+        self::save_entries($entries);
+    }
+
+    public static function get_entries($args = []) {
+        $defaults = [
+            'per_page' => 10,
+            'paged'    => 1,
+        ];
+
+        $args = wp_parse_args($args, $defaults);
+
+        $per_page = isset($args['per_page']) ? (int) $args['per_page'] : 10;
+        $per_page = $per_page > 0 ? $per_page : 10;
+
+        $current_page = isset($args['paged']) ? (int) $args['paged'] : 1;
+        $current_page = $current_page > 0 ? $current_page : 1;
+
+        $entries = self::get_raw_entries();
+        $total   = count($entries);
+
+        $offset = ($current_page - 1) * $per_page;
+        $offset = $offset < 0 ? 0 : $offset;
+
+        $page_entries = array_slice($entries, $offset, $per_page);
+
+        $total_pages = 0 === $per_page ? 1 : (int) ceil($total / $per_page);
+        $total_pages = $total_pages > 0 ? $total_pages : 1;
+
+        return [
+            'entries'       => $page_entries,
+            'total'         => $total,
+            'total_pages'   => $total_pages,
+            'per_page'      => $per_page,
+            'current_page'  => $current_page,
+        ];
+    }
+
+    public static function count_entries() {
+        return count(self::get_raw_entries());
+    }
+
+    public static function clear_history() {
+        delete_option(self::OPTION_NAME);
+    }
+
+    private static function build_entry_from_job(array $job, array $context) {
+        $job_id = isset($job['id']) ? (string) $job['id'] : '';
+
+        if ('' === $job_id) {
+            return null;
+        }
+
+        $status = isset($job['status']) ? (string) $job['status'] : '';
+
+        $timestamps = [
+            isset($job['completed_at']) ? (int) $job['completed_at'] : 0,
+            isset($job['updated_at']) ? (int) $job['updated_at'] : 0,
+            isset($job['created_at']) ? (int) $job['created_at'] : 0,
+            isset($context['timestamp']) ? (int) $context['timestamp'] : 0,
+        ];
+
+        $timestamp = time();
+
+        foreach ($timestamps as $candidate) {
+            if ($candidate > 0) {
+                $timestamp = $candidate;
+                break;
+            }
+        }
+
+        $user_id = 0;
+
+        if (isset($context['user_id'])) {
+            $user_id = (int) $context['user_id'];
+        } elseif (isset($job['created_by'])) {
+            $user_id = (int) $job['created_by'];
+        } elseif (function_exists('get_current_user_id')) {
+            $user_id = (int) get_current_user_id();
+        }
+
+        $user_name = '';
+
+        if (isset($context['user_name']) && is_string($context['user_name'])) {
+            $user_name = $context['user_name'];
+        } elseif (!empty($job['created_by_name']) && is_string($job['created_by_name'])) {
+            $user_name = $job['created_by_name'];
+        } elseif ($user_id > 0) {
+            $user = get_userdata($user_id);
+
+            if ($user instanceof WP_User) {
+                $user_name = $user->display_name;
+            }
+        }
+
+        $user_name = sanitize_text_field($user_name);
+
+        $zip_path = isset($job['zip_path']) ? (string) $job['zip_path'] : '';
+        $zip_file_name = isset($job['zip_file_name']) && '' !== $job['zip_file_name']
+            ? (string) $job['zip_file_name']
+            : ($zip_path !== '' ? basename($zip_path) : '');
+
+        $zip_file_size = isset($job['zip_file_size']) ? (int) $job['zip_file_size'] : 0;
+
+        if ($zip_file_size <= 0 && '' !== $zip_path && file_exists($zip_path)) {
+            $zip_file_size = (int) filesize($zip_path);
+        }
+
+        $exclusions = [];
+
+        if (isset($job['exclusions']) && is_array($job['exclusions'])) {
+            $exclusions = array_values(
+                array_filter(
+                    array_map(
+                        static function ($pattern) {
+                            return (string) $pattern;
+                        },
+                        $job['exclusions']
+                    ),
+                    static function ($pattern) {
+                        return '' !== trim($pattern);
+                    }
+                )
+            );
+        }
+
+        $origin = '';
+
+        if (isset($context['origin'])) {
+            $origin = (string) $context['origin'];
+        } elseif (isset($job['created_via'])) {
+            $origin = (string) $job['created_via'];
+        } elseif (defined('WP_CLI') && WP_CLI) {
+            $origin = 'cli';
+        } else {
+            $origin = 'web';
+        }
+
+        $entry = [
+            'job_id'        => $job_id,
+            'status'        => $status,
+            'timestamp'     => $timestamp,
+            'user_id'       => $user_id,
+            'user_name'     => $user_name,
+            'zip_file_name' => $zip_file_name,
+            'zip_file_size' => max(0, $zip_file_size),
+            'exclusions'    => $exclusions,
+            'origin'        => $origin,
+        ];
+
+        if (!empty($job['persistent_path']) && is_string($job['persistent_path'])) {
+            $entry['persistent_path'] = $job['persistent_path'];
+        }
+
+        if (!empty($job['persistent_url']) && is_string($job['persistent_url'])) {
+            $entry['persistent_url'] = $job['persistent_url'];
+        }
+
+        if (isset($context['download_url']) && is_string($context['download_url'])) {
+            $entry['persistent_url'] = $context['download_url'];
+        }
+
+        $entry = apply_filters('tejlg_export_history_entry', $entry, $job, $context);
+
+        return self::normalize_entry($entry);
+    }
+
+    private static function normalize_entry($entry) {
+        if (!is_array($entry) || empty($entry['job_id'])) {
+            return null;
+        }
+
+        $entry['job_id'] = (string) $entry['job_id'];
+        $entry['status'] = isset($entry['status']) ? (string) $entry['status'] : '';
+
+        $timestamp = isset($entry['timestamp']) ? (int) $entry['timestamp'] : time();
+        $entry['timestamp'] = $timestamp > 0 ? $timestamp : time();
+
+        $entry['user_id'] = isset($entry['user_id']) ? (int) $entry['user_id'] : 0;
+        $entry['user_name'] = isset($entry['user_name']) ? sanitize_text_field($entry['user_name']) : '';
+        $entry['zip_file_name'] = isset($entry['zip_file_name']) ? sanitize_text_field((string) $entry['zip_file_name']) : '';
+        $entry['zip_file_size'] = isset($entry['zip_file_size']) ? max(0, (int) $entry['zip_file_size']) : 0;
+        $entry['origin'] = isset($entry['origin']) ? sanitize_key($entry['origin']) : '';
+
+        $exclusions = isset($entry['exclusions']) ? (array) $entry['exclusions'] : [];
+        $entry['exclusions'] = array_values(
+            array_filter(
+                array_map(
+                    static function ($pattern) {
+                        return (string) $pattern;
+                    },
+                    $exclusions
+                ),
+                static function ($pattern) {
+                    return '' !== trim($pattern);
+                }
+            )
+        );
+
+        if (isset($entry['persistent_path']) && is_string($entry['persistent_path'])) {
+            $entry['persistent_path'] = sanitize_text_field($entry['persistent_path']);
+        }
+
+        if (isset($entry['persistent_url']) && is_string($entry['persistent_url'])) {
+            $entry['persistent_url'] = esc_url_raw($entry['persistent_url']);
+        }
+
+        return $entry;
+    }
+
+    private static function get_raw_entries() {
+        $stored = get_option(self::OPTION_NAME, []);
+
+        if (!is_array($stored)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($stored as $entry) {
+            $normalized_entry = self::normalize_entry($entry);
+
+            if (null !== $normalized_entry) {
+                $normalized[] = $normalized_entry;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private static function save_entries(array $entries) {
+        $entries = array_values($entries);
+
+        update_option(self::OPTION_NAME, $entries, false);
+    }
+}

--- a/theme-export-jlg/theme-export-jlg.php
+++ b/theme-export-jlg/theme-export-jlg.php
@@ -25,6 +25,7 @@ define( 'TEJLG_URL', plugin_dir_url( __FILE__ ) );
 
 // Charger les classes nécessaires
 require_once TEJLG_PATH . 'includes/class-tejlg-admin.php';
+require_once TEJLG_PATH . 'includes/class-tejlg-export-history.php';
 require_once TEJLG_PATH . 'includes/class-wp-background-process.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-zip-writer.php';
 require_once TEJLG_PATH . 'includes/class-tejlg-export-process.php';


### PR DESCRIPTION
## Summary
- add a TEJLG_Export_History service that stores completed job metadata in a non-autoloaded option and enrich export jobs with author/context info
- hook job deletion paths, the admin export page, and the CLI to record and expose historical entries, including a new `history` subcommand
- cover history persistence and rendering with dedicated PHPUnit tests and extend existing CLI tests

## Testing
- npm run test:php *(fails: phpunit not found in container)*
- php -l theme-export-jlg/includes/class-tejlg-export-history.php
- php -l theme-export-jlg/templates/admin/export.php
- php -l theme-export-jlg/includes/class-tejlg-cli.php
- php -l theme-export-jlg/includes/class-tejlg-admin-export-page.php
- php -l theme-export-jlg/includes/class-tejlg-export.php

------
https://chatgpt.com/codex/tasks/task_e_68e12d553d14832e8524ad1def6d535a