### PR TITLE
Add cancel option to theme export process

### DIFF
--- a/tests/test-ajax-theme-export.php
+++ b/tests/test-ajax-theme-export.php
@@ -70,4 +70,150 @@ class Test_Ajax_Theme_Export extends WP_Ajax_UnitTestCase {
 
         $_POST = $original_post;
     }
+
+    public function test_cancel_theme_export_cancels_job_and_cleans_resources() {
+        $user_id = self::factory()->user->create([
+            'role' => 'administrator',
+        ]);
+
+        wp_set_current_user($user_id);
+
+        $job_id = 'tejlg_test_cancel_job';
+        $temp_zip = tempnam(sys_get_temp_dir(), 'tejlg');
+        file_put_contents($temp_zip, 'temporary archive');
+
+        $job = [
+            'id'                => $job_id,
+            'status'            => 'processing',
+            'progress'          => 45,
+            'processed_items'   => 9,
+            'total_items'       => 20,
+            'zip_path'          => $temp_zip,
+            'zip_file_name'     => 'cancel-test.zip',
+            'directories_added' => [],
+            'exclusions'        => [],
+            'created_at'        => time() - 60,
+            'updated_at'        => time() - 30,
+        ];
+
+        TEJLG_Export::persist_job($job);
+
+        update_user_meta($user_id, '_tejlg_last_theme_export_job_id', $job_id);
+
+        $queue_option_name = 'wp_background_process_tejlg_theme_export_queue';
+        $other_job_id      = 'tejlg_other_job';
+
+        update_option(
+            $queue_option_name,
+            [
+                [
+                    [
+                        'job_id'               => $job_id,
+                        'type'                 => 'file',
+                        'real_path'            => __FILE__,
+                        'relative_path_in_zip' => 'theme/file.php',
+                    ],
+                    [
+                        'job_id'               => $other_job_id,
+                        'type'                 => 'file',
+                        'real_path'            => __FILE__,
+                        'relative_path_in_zip' => 'other/file.php',
+                    ],
+                ],
+                [
+                    [
+                        'job_id'               => $job_id,
+                        'type'                 => 'dir',
+                        'real_path'            => dirname(__FILE__),
+                        'relative_path_in_zip' => 'theme/',
+                    ],
+                ],
+            ],
+            false
+        );
+
+        $original_post = $_POST;
+
+        $_POST = [
+            'nonce'  => wp_create_nonce('tejlg_cancel_theme_export'),
+            'job_id' => $job_id,
+        ];
+
+        try {
+            $this->_handleAjax('tejlg_cancel_theme_export');
+        } catch (WPAjaxDieContinueException $exception) {
+            // Expected behaviour for AJAX handlers in tests.
+        }
+
+        $this->assertNotEmpty($this->_last_response, 'The AJAX handler should return a payload.');
+
+        $response = json_decode($this->_last_response, true);
+
+        $this->assertIsArray($response, 'The response should decode to an array.');
+        $this->assertArrayHasKey('success', $response, 'The response should contain a success flag.');
+        $this->assertTrue($response['success'], 'The AJAX request should be successful.');
+        $this->assertArrayHasKey('data', $response, 'The response should contain a data payload.');
+        $this->assertArrayHasKey('job', $response['data'], 'The response data should include the job payload.');
+
+        $job_response = $response['data']['job'];
+
+        $this->assertSame('cancelled', $job_response['status'], 'The response job status should be cancelled.');
+        $this->assertSame(0, $job_response['progress'], 'The response job progress should be reset.');
+
+        $stored_job = TEJLG_Export::get_job($job_id);
+
+        $this->assertIsArray($stored_job, 'The cancelled job should remain stored.');
+        $this->assertSame('cancelled', $stored_job['status'], 'The stored job status should be cancelled.');
+        $this->assertSame(0, $stored_job['progress'], 'The stored job progress should be reset.');
+        $this->assertSame(0, $stored_job['processed_items'], 'The processed items count should be reset.');
+        $this->assertArrayHasKey('cancelled_at', $stored_job, 'The cancelled job should include a cancellation timestamp.');
+        $this->assertEmpty($stored_job['zip_path'], 'The temporary ZIP path should be cleared after cancellation.');
+        $this->assertSame(0, $stored_job['zip_file_size'], 'The ZIP file size should be reset after cancellation.');
+
+        $this->assertFalse(file_exists($temp_zip), 'The temporary ZIP file should be deleted.');
+
+        $queue = get_option($queue_option_name, []);
+
+        $this->assertIsArray($queue, 'The queue option should remain an array.');
+
+        $remaining_items = [];
+
+        foreach ($queue as $batch) {
+            if (!is_array($batch)) {
+                continue;
+            }
+            foreach ($batch as $item) {
+                if (!is_array($item)) {
+                    continue;
+                }
+                $remaining_items[] = $item;
+            }
+        }
+
+        $this->assertNotEmpty($remaining_items, 'Other jobs should remain in the queue.');
+
+        foreach ($remaining_items as $item) {
+            if (isset($item['job_id'])) {
+                $this->assertNotSame($job_id, sanitize_key((string) $item['job_id']), 'The cancelled job should be removed from the queue.');
+            }
+        }
+
+        $other_job_found = false;
+        foreach ($remaining_items as $item) {
+            if (isset($item['job_id']) && sanitize_key((string) $item['job_id']) === sanitize_key($other_job_id)) {
+                $other_job_found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($other_job_found, 'Unrelated jobs should remain queued.');
+
+        $user_meta = get_user_meta($user_id, '_tejlg_last_theme_export_job_id', true);
+        $this->assertEmpty($user_meta, 'The user job reference should be cleared.');
+
+        TEJLG_Export::delete_job($job_id);
+        delete_option($queue_option_name);
+
+        $_POST = $original_post;
+    }
 }

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -118,10 +118,12 @@ class TEJLG_Admin {
                         'start'    => 'tejlg_start_theme_export',
                         'status'   => 'tejlg_theme_export_status',
                         'download' => 'tejlg_download_theme_export',
+                        'cancel'   => 'tejlg_cancel_theme_export',
                     ],
                     'nonces' => [
-                        'start'  => wp_create_nonce('tejlg_start_theme_export'),
-                        'status' => wp_create_nonce('tejlg_theme_export_status'),
+                        'start'   => wp_create_nonce('tejlg_start_theme_export'),
+                        'status'  => wp_create_nonce('tejlg_theme_export_status'),
+                        'cancel'  => wp_create_nonce('tejlg_cancel_theme_export'),
                     ],
                     'pollInterval' => 4000,
                     'strings' => [
@@ -132,6 +134,8 @@ class TEJLG_Admin {
                         'completed'       => esc_html__('Export terminé !', 'theme-export-jlg'),
                         'failed'          => esc_html__("Échec de l'export : %1$s", 'theme-export-jlg'),
                         'downloadLabel'   => esc_html__("Télécharger l'archive ZIP", 'theme-export-jlg'),
+                        'cancelling'      => esc_html__('Annulation…', 'theme-export-jlg'),
+                        'cancelled'       => esc_html__('Export annulé.', 'theme-export-jlg'),
                         'unknownError'    => esc_html__('Une erreur inattendue est survenue.', 'theme-export-jlg'),
                         'statusLabel'     => esc_html__('Statut de la tâche : %1$s', 'theme-export-jlg'),
                     ],

--- a/theme-export-jlg/templates/admin/export.php
+++ b/theme-export-jlg/templates/admin/export.php
@@ -59,6 +59,7 @@ $select_patterns_url = add_query_arg([
                         data-export-progress-bar
                     ></progress>
                     <p class="description" data-export-message></p>
+                    <p><button type="button" class="button button-secondary wp-ui-secondary" data-export-cancel><?php esc_html_e("Annuler l'export", 'theme-export-jlg'); ?></button></p>
                     <p><a href="#" class="button button-secondary wp-ui-secondary" data-export-download hidden target="_blank" rel="noopener"><?php esc_html_e("Télécharger l'archive ZIP", 'theme-export-jlg'); ?></a></p>
                 </div>
             </form>

--- a/theme-export-jlg/theme-export-jlg.php
+++ b/theme-export-jlg/theme-export-jlg.php
@@ -51,6 +51,7 @@ function tejlg_load_textdomain() {
 add_action('wp_ajax_tejlg_start_theme_export', ['TEJLG_Export', 'ajax_start_theme_export']);
 add_action('wp_ajax_tejlg_theme_export_status', ['TEJLG_Export', 'ajax_get_theme_export_status']);
 add_action('wp_ajax_tejlg_download_theme_export', ['TEJLG_Export', 'ajax_download_theme_export']);
+add_action('wp_ajax_tejlg_cancel_theme_export', ['TEJLG_Export', 'ajax_cancel_theme_export']);
 add_action('admin_init', ['TEJLG_Export', 'cleanup_stale_jobs']);
 add_action( 'plugins_loaded', 'tejlg_load_textdomain' );
 add_action( 'plugins_loaded', 'tejlg_run_plugin' );


### PR DESCRIPTION
## Summary
- add a cancel button to the async export UI and surface new status strings
- implement server-side cancellation handling, including queue cleanup and status updates
- extend the background process helper and AJAX tests to cover the cancel flow

## Testing
- npm run test:php *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e12d544914832ebe66736de006156c