### PR TITLE
Handle stale export job inactivity and improve admin feedback

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -139,6 +139,10 @@ class TEJLG_Admin {
                         'cancelled'       => esc_html__('Export annulé.', 'theme-export-jlg'),
                         'cancelling'      => esc_html__('Annulation…', 'theme-export-jlg'),
                         'cancelFailed'    => esc_html__("Impossible d'annuler l'export.", 'theme-export-jlg'),
+                        'autoFailedStatus' => esc_html__('Export interrompu pour inactivité.', 'theme-export-jlg'),
+                        'autoFailedMessage' => esc_html__('La tâche est restée inactive trop longtemps et a été arrêtée automatiquement.', 'theme-export-jlg'),
+                        'cancelledStatus' => esc_html__('Export annulé.', 'theme-export-jlg'),
+                        'cancelledMessage' => esc_html__("L'export a été annulé. Aucun fichier n'a été généré.", 'theme-export-jlg'),
                     ],
                     'previousJob' => TEJLG_Export::get_current_user_job_snapshot(),
                     'defaults'    => [

--- a/theme-export-jlg/includes/class-tejlg-export-process.php
+++ b/theme-export-jlg/includes/class-tejlg-export-process.php
@@ -43,6 +43,13 @@ class TEJLG_Export_Process extends WP_Background_Process {
             return false;
         }
 
+        if (isset($job['failure_code'])) {
+            unset($job['failure_code']);
+        }
+
+        $job['updated_at'] = time();
+        TEJLG_Export::persist_job($job);
+
         $type               = isset($item['type']) ? $item['type'] : '';
         $real_path          = isset($item['real_path']) ? (string) $item['real_path'] : '';
         $relative_path_in_zip = isset($item['relative_path_in_zip']) ? (string) $item['relative_path_in_zip'] : '';


### PR DESCRIPTION
## Summary
- mark queued and processing exports as failed when they remain inactive past the cleanup threshold and record a timeout failure code
- refresh export job timestamps during background processing and expose failure codes to the admin UI
- tweak admin messaging for cancelled/auto-failed jobs and add a regression test covering stale job cleanup

## Testing
- Not run (phpunit binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e148e567a4832ebde15f945929ddc5