### PR TITLE
Fix preview controller WeakMap reuse

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -1412,8 +1412,6 @@ document.addEventListener('DOMContentLoaded', function() {
             return rect.top < viewHeight && rect.bottom > 0;
         };
 
-        const previewControllers = new WeakMap();
-
         const intersectionObserver = (typeof IntersectionObserver === 'function')
             ? new IntersectionObserver(function(entries) {
                 entries.forEach(function(entry) {


### PR DESCRIPTION
## Summary
- reuse a single WeakMap for preview controllers across width controls and observers
- ensure width sync retrieves controllers stored during creation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a3bcc76c832e84be9a141369f2ce