### PR TITLE
Enhance admin import dropzone UX

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -46,14 +46,19 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
-    padding: 1rem;
+    gap: 0.75rem;
+    padding: 1.25rem;
     margin: 0 0 1rem;
     border: 2px dashed var(--tejlg-border-color);
     border-radius: var(--wp-admin-border-radius, 4px);
     background-color: var(--tejlg-surface-alt-color);
     cursor: pointer;
-    transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.tejlg-dropzone:hover {
+    border-color: color-mix(in srgb, var(--tejlg-accent-color) 40%, var(--tejlg-border-color));
+    background-color: color-mix(in srgb, var(--tejlg-accent-color) 6%, var(--tejlg-surface-alt-color));
 }
 
 .tejlg-dropzone:focus-visible {
@@ -67,7 +72,17 @@
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tejlg-accent-color) 30%, transparent);
 }
 
-.tejlg-dropzone label {
+.tejlg-dropzone__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.tejlg-dropzone__title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin: 0;
     font-weight: 600;
     cursor: pointer;
 }
@@ -78,8 +93,17 @@
     font-size: 0.95em;
 }
 
-.tejlg-dropzone input[type="file"] {
-    max-width: 100%;
+.tejlg-dropzone__input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 .metrics-badge {

--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -52,14 +52,25 @@ document.addEventListener('DOMContentLoaded', function() {
             const setDragState = function(isActive) {
                 if (isActive) {
                     dropzone.classList.add('is-dragover');
+                    dropzone.setAttribute('data-tejlg-dropzone-state', 'dragover');
                 } else {
                     dropzone.classList.remove('is-dragover');
+                    dropzone.setAttribute('data-tejlg-dropzone-state', 'idle');
                 }
             };
+
+            setDragState(false);
 
             ['dragenter', 'dragover'].forEach(function(eventName) {
                 dropzone.addEventListener(eventName, function(event) {
                     preventDefaults(event);
+                    if (event.dataTransfer) {
+                        try {
+                            event.dataTransfer.dropEffect = 'copy';
+                        } catch (error) {
+                            // Certains navigateurs empêchent l'écriture directe du dropEffect.
+                        }
+                    }
                     setDragState(true);
                 });
             });
@@ -91,6 +102,18 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
 
                 fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+                if (typeof dropzone.focus === 'function') {
+                    try {
+                        dropzone.focus({ preventScroll: true });
+                    } catch (error) {
+                        dropzone.focus();
+                    }
+                }
+            });
+
+            dropzone.addEventListener('dragend', function() {
+                setDragState(false);
             });
 
             dropzone.addEventListener('click', function(event) {

--- a/theme-export-jlg/templates/admin/import.php
+++ b/theme-export-jlg/templates/admin/import.php
@@ -18,10 +18,12 @@ $import_tab_url = add_query_arg([
             <form id="tejlg-import-theme-form" method="post" action="<?php echo esc_url($import_tab_url); ?>" enctype="multipart/form-data">
                 <?php wp_nonce_field('tejlg_import_theme_action', 'tejlg_import_theme_nonce'); ?>
                 <input type="hidden" name="tejlg_confirm_theme_overwrite" id="tejlg_confirm_theme_overwrite" value="<?php echo esc_attr('0'); ?>">
-                <div class="tejlg-dropzone" data-tejlg-dropzone role="group" aria-labelledby="theme_zip_label" aria-describedby="theme_zip_instructions" tabindex="0">
-                    <label id="theme_zip_label" for="theme_zip"><?php echo esc_html(sprintf(__('Fichier du thème (%s) :', 'theme-export-jlg'), $theme_file_info['display'])); ?></label>
-                    <p id="theme_zip_instructions" class="tejlg-dropzone__instructions"><?php esc_html_e('Glissez-déposez votre fichier ici ou cliquez pour parcourir votre ordinateur.', 'theme-export-jlg'); ?></p>
-                    <input type="file" id="theme_zip" name="theme_zip" accept="<?php echo esc_attr($theme_file_info['accept']); ?>" required>
+                <div class="tejlg-dropzone" data-tejlg-dropzone data-tejlg-dropzone-state="idle" role="button" aria-labelledby="theme_zip_label" aria-describedby="theme_zip_instructions" tabindex="0">
+                    <div class="tejlg-dropzone__content">
+                        <label class="tejlg-dropzone__title" id="theme_zip_label" for="theme_zip"><?php echo esc_html(sprintf(__('Fichier du thème (%s)', 'theme-export-jlg'), $theme_file_info['display'])); ?></label>
+                        <p id="theme_zip_instructions" class="tejlg-dropzone__instructions"><?php esc_html_e('Glissez-déposez votre fichier ici ou utilisez la touche Entrée ou l’espace pour parcourir vos fichiers.', 'theme-export-jlg'); ?></p>
+                    </div>
+                    <input class="tejlg-dropzone__input" type="file" id="theme_zip" name="theme_zip" accept="<?php echo esc_attr($theme_file_info['accept']); ?>" required>
                 </div>
                 <p><button type="submit" name="tejlg_import_theme" class="button button-primary wp-ui-primary"><?php esc_html_e('Importer le Thème', 'theme-export-jlg'); ?></button></p>
             </form>
@@ -33,10 +35,12 @@ $import_tab_url = add_query_arg([
             <p><?php echo wp_kses_post(sprintf(__('Téléversez un fichier %s (généré par l\'export). Vous pourrez choisir quelles compositions importer à l\'étape suivante.', 'theme-export-jlg'), $patterns_file_info['code'])); ?></p>
             <form method="post" action="<?php echo esc_url($import_tab_url); ?>" enctype="multipart/form-data">
                 <?php wp_nonce_field('tejlg_import_patterns_step1_action', 'tejlg_import_patterns_step1_nonce'); ?>
-                <div class="tejlg-dropzone" data-tejlg-dropzone role="group" aria-labelledby="patterns_json_label" aria-describedby="patterns_json_instructions" tabindex="0">
-                    <label id="patterns_json_label" for="patterns_json"><?php echo esc_html(sprintf(__('Fichier des compositions (%s) :', 'theme-export-jlg'), $patterns_file_info['display'])); ?></label>
-                    <p id="patterns_json_instructions" class="tejlg-dropzone__instructions"><?php esc_html_e('Glissez-déposez votre fichier ici ou cliquez pour parcourir votre ordinateur.', 'theme-export-jlg'); ?></p>
-                    <input type="file" id="patterns_json" name="patterns_json" accept="<?php echo esc_attr($patterns_file_info['accept']); ?>" required>
+                <div class="tejlg-dropzone" data-tejlg-dropzone data-tejlg-dropzone-state="idle" role="button" aria-labelledby="patterns_json_label" aria-describedby="patterns_json_instructions" tabindex="0">
+                    <div class="tejlg-dropzone__content">
+                        <label class="tejlg-dropzone__title" id="patterns_json_label" for="patterns_json"><?php echo esc_html(sprintf(__('Fichier des compositions (%s)', 'theme-export-jlg'), $patterns_file_info['display'])); ?></label>
+                        <p id="patterns_json_instructions" class="tejlg-dropzone__instructions"><?php esc_html_e('Glissez-déposez votre fichier ici ou utilisez la touche Entrée ou l’espace pour parcourir vos fichiers.', 'theme-export-jlg'); ?></p>
+                    </div>
+                    <input class="tejlg-dropzone__input" type="file" id="patterns_json" name="patterns_json" accept="<?php echo esc_attr($patterns_file_info['accept']); ?>" required>
                 </div>
                 <p><button type="submit" name="tejlg_import_patterns_step1" class="button button-primary wp-ui-primary"><?php esc_html_e('Analyser et prévisualiser', 'theme-export-jlg'); ?></button></p>
             </form>
@@ -48,10 +52,12 @@ $import_tab_url = add_query_arg([
             <p><?php echo wp_kses_post(sprintf(__('Téléversez le fichier exporté des réglages globaux (%s) pour appliquer les mêmes paramètres <code>theme.json</code> sur ce site.', 'theme-export-jlg'), $global_styles_file_info['code'])); ?></p>
             <form method="post" action="<?php echo esc_url($import_tab_url); ?>" enctype="multipart/form-data">
                 <?php wp_nonce_field('tejlg_import_global_styles_action', 'tejlg_import_global_styles_nonce'); ?>
-                <div class="tejlg-dropzone" data-tejlg-dropzone role="group" aria-labelledby="global_styles_json_label" aria-describedby="global_styles_json_instructions" tabindex="0">
-                    <label id="global_styles_json_label" for="global_styles_json"><?php echo esc_html(sprintf(__('Fichier des styles globaux (%s) :', 'theme-export-jlg'), $global_styles_file_info['display'])); ?></label>
-                    <p id="global_styles_json_instructions" class="tejlg-dropzone__instructions"><?php esc_html_e('Glissez-déposez votre fichier ici ou cliquez pour parcourir votre ordinateur.', 'theme-export-jlg'); ?></p>
-                    <input type="file" id="global_styles_json" name="global_styles_json" accept="<?php echo esc_attr($global_styles_file_info['accept']); ?>" required>
+                <div class="tejlg-dropzone" data-tejlg-dropzone data-tejlg-dropzone-state="idle" role="button" aria-labelledby="global_styles_json_label" aria-describedby="global_styles_json_instructions" tabindex="0">
+                    <div class="tejlg-dropzone__content">
+                        <label class="tejlg-dropzone__title" id="global_styles_json_label" for="global_styles_json"><?php echo esc_html(sprintf(__('Fichier des styles globaux (%s)', 'theme-export-jlg'), $global_styles_file_info['display'])); ?></label>
+                        <p id="global_styles_json_instructions" class="tejlg-dropzone__instructions"><?php esc_html_e('Glissez-déposez votre fichier ici ou utilisez la touche Entrée ou l’espace pour parcourir vos fichiers.', 'theme-export-jlg'); ?></p>
+                    </div>
+                    <input class="tejlg-dropzone__input" type="file" id="global_styles_json" name="global_styles_json" accept="<?php echo esc_attr($global_styles_file_info['accept']); ?>" required>
                 </div>
                 <p><button type="submit" name="tejlg_import_global_styles" class="button button-primary wp-ui-primary"><?php esc_html_e('Importer les styles globaux', 'theme-export-jlg'); ?></button></p>
             </form>


### PR DESCRIPTION
## Summary
- wrap each admin import dropzone in an accessible container with revised instructions
- extend dropzone styling for dashed borders, hover, and drag-over states
- update admin scripts to manage drag-and-drop interactions and keep file inputs in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a945c470832e9773ce00c7321395