### PR TITLE
Add exclusion pattern preview tester

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -106,6 +106,81 @@
     white-space: nowrap;
 }
 
+.tejlg-pattern-test {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.tejlg-pattern-test__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.tejlg-pattern-test__feedback {
+    margin: 0;
+}
+
+.tejlg-pattern-test__summary {
+    font-weight: 600;
+    margin: 0 0 0.25rem;
+}
+
+.tejlg-pattern-test__message {
+    margin: 0 0 0.5rem;
+}
+
+.tejlg-pattern-test__lists {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.tejlg-pattern-test__list {
+    background: var(--tejlg-surface-alt-color);
+    border: 1px solid var(--tejlg-border-color);
+    border-radius: var(--wp-admin-border-radius, 4px);
+    padding: 0.75rem;
+}
+
+.tejlg-pattern-test__list h4 {
+    margin: 0 0 0.5rem;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.tejlg-pattern-test__list ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    max-height: 200px;
+    overflow-y: auto;
+    font-size: 13px;
+}
+
+.tejlg-pattern-test__list ul li {
+    word-break: break-word;
+}
+
+.tejlg-pattern-test__list ul li.is-empty {
+    list-style: none;
+    padding-left: 0;
+    color: var(--tejlg-text-muted-color);
+}
+
+.tejlg-pattern-test__invalid {
+    margin: 0;
+    color: #dc3232;
+    font-weight: 600;
+}
+
+textarea.has-pattern-error {
+    border-color: #dc3232;
+    box-shadow: 0 0 0 1px rgba(220, 50, 50, 0.2);
+}
+
 .metrics-badge {
     display: inline-flex;
     flex-direction: column;

--- a/theme-export-jlg/includes/class-tejlg-admin.php
+++ b/theme-export-jlg/includes/class-tejlg-admin.php
@@ -148,6 +148,19 @@ class TEJLG_Admin {
                     'defaults'    => [
                         'exclusions' => $saved_exclusions,
                     ],
+                    'patternTester' => [
+                        'action' => 'tejlg_preview_exclusion_patterns',
+                        'nonce'  => wp_create_nonce('tejlg_preview_exclusion_patterns'),
+                        'strings' => [
+                            'summary'        => esc_html__('%1$d fichier(s) inclus, %2$d exclu(s).', 'theme-export-jlg'),
+                            'emptyList'      => esc_html__('Aucun fichier listé.', 'theme-export-jlg'),
+                            'invalidPatterns' => esc_html__('Motifs invalides : %1$s', 'theme-export-jlg'),
+                            'unknownError'   => esc_html__('Une erreur inattendue est survenue lors du test des motifs.', 'theme-export-jlg'),
+                            'requestFailed'  => esc_html__('La requête a échoué. Veuillez réessayer.', 'theme-export-jlg'),
+                            'successMessage' => esc_html__('Aperçu généré avec succès.', 'theme-export-jlg'),
+                            'listSeparator'  => esc_html__(', ', 'theme-export-jlg'),
+                        ],
+                    ],
                 ],
             ]
         );

--- a/theme-export-jlg/templates/admin/export.php
+++ b/theme-export-jlg/templates/admin/export.php
@@ -46,6 +46,33 @@ $select_patterns_url = add_query_arg([
                         aria-describedby="tejlg_exclusion_patterns_description"
                     ><?php echo esc_textarea($exclusion_patterns_value); ?></textarea>
                     <span id="tejlg_exclusion_patterns_description" class="description"><?php esc_html_e('Indiquez un motif par ligne ou séparez-les par des virgules (joker * accepté).', 'theme-export-jlg'); ?></span>
+                    <div class="tejlg-pattern-test" data-pattern-test>
+                        <div class="tejlg-pattern-test__actions">
+                            <button
+                                type="button"
+                                class="button button-secondary wp-ui-secondary"
+                                data-pattern-test-trigger
+                                aria-describedby="tejlg-pattern-test-help"
+                            ><?php esc_html_e('Tester les motifs', 'theme-export-jlg'); ?></button>
+                            <span class="spinner" aria-hidden="true" data-pattern-test-spinner></span>
+                        </div>
+                        <p id="tejlg-pattern-test-help" class="description"><?php esc_html_e('Vérifiez les fichiers inclus/exclus avant de lancer un export.', 'theme-export-jlg'); ?></p>
+                        <p class="tejlg-pattern-test__invalid" data-pattern-test-invalid hidden></p>
+                        <div class="tejlg-pattern-test__feedback notice notice-info" data-pattern-test-feedback hidden>
+                            <p class="tejlg-pattern-test__summary" data-pattern-test-summary></p>
+                            <p class="tejlg-pattern-test__message" data-pattern-test-message></p>
+                            <div class="tejlg-pattern-test__lists" data-pattern-test-lists>
+                                <div class="tejlg-pattern-test__list">
+                                    <h4><?php esc_html_e('Fichiers inclus', 'theme-export-jlg'); ?></h4>
+                                    <ul data-pattern-test-included></ul>
+                                </div>
+                                <div class="tejlg-pattern-test__list">
+                                    <h4><?php esc_html_e('Fichiers exclus', 'theme-export-jlg'); ?></h4>
+                                    <ul data-pattern-test-excluded></ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </p>
                 <p class="tejlg-theme-export-actions">
                     <button type="submit" class="button button-primary wp-ui-primary" data-export-start><?php esc_html_e("Lancer l'export du thème", 'theme-export-jlg'); ?></button>

--- a/theme-export-jlg/theme-export-jlg.php
+++ b/theme-export-jlg/theme-export-jlg.php
@@ -53,6 +53,7 @@ add_action('wp_ajax_tejlg_start_theme_export', ['TEJLG_Export', 'ajax_start_them
 add_action('wp_ajax_tejlg_theme_export_status', ['TEJLG_Export', 'ajax_get_theme_export_status']);
 add_action('wp_ajax_tejlg_download_theme_export', ['TEJLG_Export', 'ajax_download_theme_export']);
 add_action('wp_ajax_tejlg_cancel_theme_export', ['TEJLG_Export', 'ajax_cancel_theme_export']);
+add_action('wp_ajax_tejlg_preview_exclusion_patterns', ['TEJLG_Admin_Export_Page', 'ajax_preview_exclusion_patterns']);
 add_action('admin_init', ['TEJLG_Export', 'cleanup_stale_jobs']);
 add_action( 'plugins_loaded', 'tejlg_load_textdomain' );
 add_action( 'plugins_loaded', 'tejlg_run_plugin' );


### PR DESCRIPTION
## Summary
- add a “Tester les motifs” preview block to the export form UI so admins can check included and excluded files before running the export
- expose a secured AJAX endpoint that reuses the export queue logic to validate motifs and return included/excluded paths
- extend the admin script, styles, and localization data to drive the tester UI and flag invalid patterns, plus add Playwright coverage for the client-side error state

## Testing
- `php -l theme-export-jlg/includes/class-tejlg-export.php`
- `npx playwright test tests/e2e/pattern-export-select-all.spec.js` *(fails: WordPress test environment REST API unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e24df34a30832ea8c01b06c8f96d46