### PR TITLE
Ensure preview controllers reuse shared WeakMap

### DIFF
--- a/theme-export-jlg/assets/js/admin-scripts.js
+++ b/theme-export-jlg/assets/js/admin-scripts.js
@@ -1211,6 +1211,16 @@ document.addEventListener('DOMContentLoaded', function() {
         previewControllers.set(wrapper, controller);
     };
 
+    const clearPreviewController = function(wrapper) {
+        if (!previewControllers || !wrapper) {
+            return;
+        }
+
+        if (typeof previewControllers.delete === 'function') {
+            previewControllers.delete(wrapper);
+        }
+    };
+
     const previewWidthControl = document.querySelector('[data-preview-width-control]');
     if (previewWidthControl && previewWrappers.length) {
         const previewWidthStrings = (typeof localization.previewWidth === 'object' && localization.previewWidth !== null)
@@ -2306,7 +2316,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
             showCompact();
 
-            return {
+            const controller = {
                 requestLoad: requestLoad,
                 collapse: collapsePreview,
                 onIntersection: onIntersection,
@@ -2321,8 +2331,13 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
 
                     cleanupPreview();
+                    clearPreviewController(wrapper);
                 },
             };
+
+            setPreviewController(wrapper, controller);
+
+            return controller;
         };
 
         previewWrappers.forEach(function(wrapper) {
@@ -2331,8 +2346,6 @@ document.addEventListener('DOMContentLoaded', function() {
             if (!controller) {
                 return;
             }
-
-            setPreviewController(wrapper, controller);
 
             if (intersectionObserver) {
                 intersectionObserver.observe(wrapper);


### PR DESCRIPTION
## Summary
- add a helper to clear preview controllers so the shared WeakMap can be reused safely
- register each preview controller in the shared WeakMap during creation so width changes can call syncHeight
- keep the intersection observer flow intact while ensuring controllers are removed from the shared registry when destroyed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2590f1b90832e981c3cf69f1227d4