### PR TITLE
Improve pattern tester accessibility feedback

### DIFF
--- a/tests/e2e/pattern-export-select-all.spec.js
+++ b/tests/e2e/pattern-export-select-all.spec.js
@@ -294,5 +294,6 @@ test.describe('Pattern export selection screen', () => {
     await expect(invalidNotice).toBeVisible();
     await expect(invalidNotice).toContainText('Motifs invalides');
     await expect(textarea).toHaveClass(/has-pattern-error/);
+    await expect(textarea).toHaveAttribute('aria-invalid', 'true');
   });
 });

--- a/theme-export-jlg/templates/admin/export.php
+++ b/theme-export-jlg/templates/admin/export.php
@@ -57,8 +57,20 @@ $select_patterns_url = add_query_arg([
                             <span class="spinner" aria-hidden="true" data-pattern-test-spinner></span>
                         </div>
                         <p id="tejlg-pattern-test-help" class="description"><?php esc_html_e('Vérifiez les fichiers inclus/exclus avant de lancer un export.', 'theme-export-jlg'); ?></p>
-                        <p class="tejlg-pattern-test__invalid" data-pattern-test-invalid hidden></p>
-                        <div class="tejlg-pattern-test__feedback notice notice-info" data-pattern-test-feedback hidden>
+                        <p
+                            class="tejlg-pattern-test__invalid"
+                            data-pattern-test-invalid
+                            role="alert"
+                            aria-live="polite"
+                            hidden
+                        ></p>
+                        <div
+                            class="tejlg-pattern-test__feedback notice notice-info"
+                            data-pattern-test-feedback
+                            role="status"
+                            aria-live="polite"
+                            hidden
+                        >
                             <p class="tejlg-pattern-test__summary" data-pattern-test-summary></p>
                             <p class="tejlg-pattern-test__message" data-pattern-test-message></p>
                             <div class="tejlg-pattern-test__lists" data-pattern-test-lists>


### PR DESCRIPTION
## Summary
- add ARIA roles to the pattern test feedback markup to announce status changes to assistive technologies
- extend the invalid pattern e2e test to assert the textarea is flagged as aria-invalid when client-side validation fails

## Testing
- npm run test:e2e -- --grep "shows an error when exclusion patterns are invalid" *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2591773d8832e89c8673ea7f284bd