### PR TITLE
Persist export archives for history links

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-cli.php
+++ b/theme-export-jlg/includes/class-tejlg-cli.php
@@ -81,10 +81,22 @@ class TEJLG_CLI {
             return;
         }
 
-        TEJLG_Export::delete_job($job_id, [
+        $persistence = TEJLG_Export::persist_export_archive($job);
+
+        $delete_context = [
             'origin' => 'cli',
             'reason' => 'exported',
-        ]);
+        ];
+
+        if (!empty($persistence['path'])) {
+            $delete_context['persistent_path'] = $persistence['path'];
+        }
+
+        if (!empty($persistence['url'])) {
+            $delete_context['download_url'] = $persistence['url'];
+        }
+
+        TEJLG_Export::delete_job($job_id, $delete_context);
 
         WP_CLI::success(sprintf(__('Archive du thème exportée vers %s', 'theme-export-jlg'), $output_path));
     }


### PR DESCRIPTION
## Summary
- add a helper that persists generated ZIP archives and returns their filesystem path and URL
- wire the AJAX download and CLI flows to persist archives and pass metadata to the history tracker
- ensure job cleanup skips persisted files while still recording download information

## Testing
- php -l theme-export-jlg/includes/class-tejlg-export.php
- php -l theme-export-jlg/includes/class-tejlg-cli.php

------
https://chatgpt.com/codex/tasks/task_e_68e267d99ae0832ea8885f368f34b3d0