### PR TITLE
Add run time control to scheduled exports

### DIFF
--- a/theme-export-jlg/includes/class-tejlg-admin-export-page.php
+++ b/theme-export-jlg/includes/class-tejlg-admin-export-page.php
@@ -65,14 +65,26 @@ class TEJLG_Admin_Export_Page extends TEJLG_Admin_Page {
         $raw_frequency  = isset($_POST['tejlg_schedule_frequency']) ? sanitize_key((string) $_POST['tejlg_schedule_frequency']) : 'disabled';
         $raw_exclusions = isset($_POST['tejlg_schedule_exclusions']) ? wp_unslash((string) $_POST['tejlg_schedule_exclusions']) : '';
         $raw_retention  = isset($_POST['tejlg_schedule_retention']) ? wp_unslash((string) $_POST['tejlg_schedule_retention']) : '';
+        $raw_run_time   = isset($_POST['tejlg_schedule_run_time']) ? wp_unslash((string) $_POST['tejlg_schedule_run_time']) : '';
 
         $retention = is_numeric($raw_retention) ? (int) $raw_retention : 0;
         $retention = $retention < 0 ? 0 : $retention;
+
+        $run_time = '';
+
+        if (is_string($raw_run_time)) {
+            $raw_run_time = trim($raw_run_time);
+
+            if (preg_match('/^([01]\d|2[0-3]):([0-5]\d)$/', $raw_run_time, $matches)) {
+                $run_time = sprintf('%02d:%02d', (int) $matches[1], (int) $matches[2]);
+            }
+        }
 
         $settings = [
             'frequency'      => $raw_frequency,
             'exclusions'     => $raw_exclusions,
             'retention_days' => $retention,
+            'run_time'       => $run_time,
         ];
 
         $normalized = TEJLG_Export::update_schedule_settings($settings);

--- a/theme-export-jlg/templates/admin/export.php
+++ b/theme-export-jlg/templates/admin/export.php
@@ -27,6 +27,21 @@ $select_patterns_url = add_query_arg([
 $schedule_frequency_value  = isset($schedule_settings['frequency']) ? (string) $schedule_settings['frequency'] : 'disabled';
 $schedule_exclusions_value = isset($schedule_settings['exclusions']) ? (string) $schedule_settings['exclusions'] : '';
 $schedule_retention_value  = isset($schedule_settings['retention_days']) ? (int) $schedule_settings['retention_days'] : 0;
+$schedule_run_time_value   = isset($schedule_settings['run_time']) ? (string) $schedule_settings['run_time'] : '00:00';
+
+if (!preg_match('/^([01]\d|2[0-3]):([0-5]\d)$/', $schedule_run_time_value)) {
+    $schedule_run_time_value = '00:00';
+}
+
+$site_timezone_string = function_exists('wp_timezone_string') ? wp_timezone_string() : get_option('timezone_string');
+
+if (!is_string($site_timezone_string) || '' === $site_timezone_string) {
+    $offset          = (float) get_option('gmt_offset', 0);
+    $offset_hours    = (int) $offset;
+    $offset_minutes  = (int) round(abs($offset - $offset_hours) * 60);
+    $offset_sign     = $offset < 0 ? '-' : '+';
+    $site_timezone_string = sprintf('%s%02d:%02d', $offset_sign, abs($offset_hours), abs($offset_minutes));
+}
 ?>
 <h2><?php esc_html_e('Actions sur le Thème Actif', 'theme-export-jlg'); ?></h2>
 <div class="tejlg-cards-container">
@@ -153,6 +168,28 @@ $schedule_retention_value  = isset($schedule_settings['retention_days']) ? (int)
                                         ?>
                                     </p>
                                 <?php endif; ?>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">
+                                <label for="tejlg_schedule_run_time"><?php esc_html_e("Heure d’exécution", 'theme-export-jlg'); ?></label>
+                            </th>
+                            <td>
+                                <input
+                                    type="time"
+                                    id="tejlg_schedule_run_time"
+                                    name="tejlg_schedule_run_time"
+                                    value="<?php echo esc_attr($schedule_run_time_value); ?>"
+                                    step="60"
+                                >
+                                <p class="description">
+                                    <?php
+                                    printf(
+                                        esc_html__('Fuseau horaire du site : %s', 'theme-export-jlg'),
+                                        esc_html($site_timezone_string)
+                                    );
+                                    ?>
+                                </p>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
## Summary
- add `run_time` defaults and normalization to schedule settings with helper to compute next timestamp
- update the admin export form to persist and display the scheduled run time and timezone context
- adapt scheduling logic to honour the selected time and expose a filter for the final timestamp, with new tests covering normalization and scheduling

## Testing
- npm test *(fails: phpunit binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e280c36fb0832e80ae68dc3074e2e9