### PR TITLE
Handle hourly and twice-daily schedule intervals

### DIFF
--- a/tests/test-export-schedule.php
+++ b/tests/test-export-schedule.php
@@ -1,0 +1,79 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+
+class Test_Export_Schedule extends WP_UnitTestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        update_option('timezone_string', 'Europe/Paris');
+    }
+
+    public function test_hourly_schedule_uses_one_hour_increments() {
+        $settings = [
+            'frequency' => 'hourly',
+            'run_time'  => '08:30',
+        ];
+
+        $reference = new DateTimeImmutable('2023-10-10 09:45:00', new DateTimeZone('Europe/Paris'));
+
+        $timestamp = TEJLG_Export::calculate_next_schedule_timestamp($settings, $reference->getTimestamp());
+
+        $next_run = (new DateTimeImmutable('@' . $timestamp))->setTimezone(new DateTimeZone('Europe/Paris'));
+
+        $this->assertSame('2023-10-10 10:30', $next_run->format('Y-m-d H:i'));
+        $this->assertSame('30', $next_run->format('i'), 'Minute should match run_time setting.');
+        $this->assertGreaterThan($reference->getTimestamp(), $timestamp);
+        $this->assertLessThanOrEqual($reference->getTimestamp() + HOUR_IN_SECONDS, $timestamp);
+    }
+
+    public function test_twicedaily_schedule_uses_twelve_hour_increments() {
+        $settings = [
+            'frequency' => 'twicedaily',
+            'run_time'  => '05:20',
+        ];
+
+        $reference = new DateTimeImmutable('2023-11-15 06:00:00', new DateTimeZone('Europe/Paris'));
+
+        $timestamp = TEJLG_Export::calculate_next_schedule_timestamp($settings, $reference->getTimestamp());
+
+        $next_run = (new DateTimeImmutable('@' . $timestamp))->setTimezone(new DateTimeZone('Europe/Paris'));
+
+        $this->assertSame('2023-11-15 17:20', $next_run->format('Y-m-d H:i'));
+        $this->assertSame('20', $next_run->format('i'), 'Minute should match run_time setting.');
+        $this->assertGreaterThan($reference->getTimestamp(), $timestamp);
+        $this->assertLessThanOrEqual($reference->getTimestamp() + (12 * HOUR_IN_SECONDS), $timestamp);
+    }
+
+    public function test_daily_schedule_rolls_over_to_next_day() {
+        $settings = [
+            'frequency' => 'daily',
+            'run_time'  => '14:45',
+        ];
+
+        $reference = new DateTimeImmutable('2023-09-12 15:00:00', new DateTimeZone('Europe/Paris'));
+
+        $timestamp = TEJLG_Export::calculate_next_schedule_timestamp($settings, $reference->getTimestamp());
+
+        $next_run = (new DateTimeImmutable('@' . $timestamp))->setTimezone(new DateTimeZone('Europe/Paris'));
+
+        $this->assertSame('2023-09-13 14:45', $next_run->format('Y-m-d H:i'));
+        $this->assertSame('45', $next_run->format('i'), 'Minute should match run_time setting.');
+    }
+
+    public function test_weekly_schedule_rolls_over_to_next_week() {
+        $settings = [
+            'frequency' => 'weekly',
+            'run_time'  => '09:10',
+        ];
+
+        $reference = new DateTimeImmutable('2023-08-01 12:00:00', new DateTimeZone('Europe/Paris'));
+
+        $timestamp = TEJLG_Export::calculate_next_schedule_timestamp($settings, $reference->getTimestamp());
+
+        $next_run = (new DateTimeImmutable('@' . $timestamp))->setTimezone(new DateTimeZone('Europe/Paris'));
+
+        $this->assertSame('2023-08-08 09:10', $next_run->format('Y-m-d H:i'));
+        $this->assertSame('10', $next_run->format('i'), 'Minute should match run_time setting.');
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -184,17 +184,56 @@ class TEJLG_Export {
         $hour           = isset($run_time_parts[0]) ? (int) $run_time_parts[0] : 0;
         $minute         = isset($run_time_parts[1]) ? (int) $run_time_parts[1] : 0;
 
-        $next_run = $now->setTime($hour, $minute, 0);
+        $next_run  = $now->setTime($hour, $minute, 0);
+        $frequency = isset($normalized['frequency']) ? (string) $normalized['frequency'] : 'daily';
 
         if ($next_run->getTimestamp() < $reference_time) {
-            if ('weekly' === $normalized['frequency']) {
-                $next_run = $next_run->modify('+1 week');
-            } else {
-                $next_run = $next_run->modify('+1 day');
+            switch ($frequency) {
+                case 'hourly':
+                    $next_run = self::advance_to_next_interval($next_run, (int) $reference_time, HOUR_IN_SECONDS);
+
+                    break;
+
+                case 'twicedaily':
+                    $next_run = self::advance_to_next_interval($next_run, (int) $reference_time, 12 * HOUR_IN_SECONDS);
+
+                    break;
+
+                case 'weekly':
+                    $next_run = $next_run->modify('+1 week');
+
+                    break;
+
+                default:
+                    $next_run = $next_run->modify('+1 day');
             }
         }
 
         return (int) $next_run->getTimestamp();
+    }
+
+    private static function advance_to_next_interval(\DateTimeImmutable $start, $reference_time, $interval_in_seconds) {
+        if ($interval_in_seconds <= 0) {
+            return $start;
+        }
+
+        $diff = $reference_time - $start->getTimestamp();
+
+        if ($diff < 0) {
+            return $start;
+        }
+
+        $steps = (int) floor($diff / $interval_in_seconds);
+
+        if ($steps > 0) {
+            $start = $start->modify(sprintf('+%d seconds', $steps * $interval_in_seconds));
+        }
+
+        if ($start->getTimestamp() < $reference_time) {
+            $start = $start->modify(sprintf('+%d seconds', $interval_in_seconds));
+        }
+
+        return $start;
     }
 
     private static function get_site_timezone() {


### PR DESCRIPTION
## Summary
- adjust the schedule timestamp calculation to advance hourly and twice-daily frequencies in their respective intervals while keeping timezone handling intact
- introduce a helper to compute the next occurrence for sub-day schedules
- add PHPUnit coverage for hourly, twice-daily, daily, and weekly schedule calculations

## Testing
- `npm run test:php` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b6ad4428832e9d3980a989b97397