### PR TITLE
Add preview UI to export selection page

### DIFF
--- a/tests/e2e/export-preview.spec.js
+++ b/tests/e2e/export-preview.spec.js
@@ -1,0 +1,32 @@
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+
+test.describe('Export pattern preview', () => {
+  test('loads the preview when requested', async ({ admin, page, requestUtils }) => {
+    await requestUtils.activatePlugin('theme-export-jlg/theme-export-jlg.php');
+
+    await requestUtils.deleteAllPosts({ postType: 'wp_block' });
+
+    await requestUtils.createPost({
+      postType: 'wp_block',
+      title: 'Previewable Pattern',
+      status: 'publish',
+      content: '<!-- wp:paragraph --><p>Preview content from export</p><!-- /wp:paragraph -->',
+    });
+
+    await admin.visitAdminPage('admin.php', 'page=theme-export-jlg&tab=export&action=select_patterns');
+
+    const patternItem = page.locator('.pattern-selection-item', { hasText: 'Previewable Pattern' });
+    const previewTrigger = patternItem.locator('.pattern-preview-trigger[data-preview-trigger="expand"]');
+    const liveContainer = patternItem.locator('.pattern-preview-live');
+    const loadingIndicator = patternItem.locator('.pattern-preview-loading');
+    await expect(previewTrigger).toBeVisible();
+
+    await previewTrigger.click();
+
+    await expect(liveContainer).toBeVisible();
+    await expect(loadingIndicator).toBeHidden();
+
+    const frameLocator = patternItem.frameLocator('.pattern-preview-iframe');
+    await expect(frameLocator.locator('p')).toHaveText('Preview content from export');
+  });
+});

--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -800,6 +800,21 @@ textarea.has-pattern-error {
     border-bottom: 1px solid color-mix(in srgb, var(--tejlg-border-color) 90%, transparent);
 }
 
+.pattern-selection-list .pattern-item {
+    border: 0;
+    margin: 0 0 1.25rem;
+    background: transparent;
+    padding: 0;
+}
+
+.pattern-selection-list .pattern-item:last-child {
+    margin-bottom: 0;
+}
+
+.pattern-selection-list .pattern-preview-wrapper {
+    margin-top: 0.75rem;
+}
+
 .pattern-selection-list li:last-child {
     border-bottom: 0;
 }

--- a/theme-export-jlg/templates/admin/export-pattern-selection.php
+++ b/theme-export-jlg/templates/admin/export-pattern-selection.php
@@ -1,6 +1,7 @@
 <?php
 /** @var string    $page_slug */
 /** @var WP_Query  $patterns_query */
+/** @var array     $pattern_entries */
 /** @var int       $per_page */
 /** @var int       $current_page */
 /** @var int       $total_pages */
@@ -14,9 +15,9 @@ $back_url = add_query_arg([
 ?>
 <p><a href="<?php echo esc_url($back_url); ?>">&larr; <?php esc_html_e('Retour aux outils principaux', 'theme-export-jlg'); ?></a></p>
 <h2><?php esc_html_e('Exporter une sélection de compositions', 'theme-export-jlg'); ?></h2>
-<p><?php echo wp_kses_post(__('Cochez les compositions que vous souhaitez inclure dans votre fichier d\'exportation <code>.json</code>.', 'theme-export-jlg')); ?></p>
+<p><?php echo wp_kses_post(__('Cochez les compositions que vous souhaitez inclure dans votre fichier d\'exportation <code>.json</code> et cliquez sur « Prévisualiser » pour vérifier le rendu avant l\'export.', 'theme-export-jlg')); ?></p>
 
-<?php if (!$patterns_query->have_posts()): ?>
+<?php if (empty($pattern_entries)): ?>
     <p><?php esc_html_e('Aucune composition personnalisée n\'a été trouvée.', 'theme-export-jlg'); ?></p>
 <?php else: ?>
     <form method="post" action="">
@@ -42,105 +43,121 @@ $back_url = add_query_arg([
                 ></p>
             </div>
             <ul class="pattern-selection-items" id="pattern-selection-items" aria-live="polite" data-searchable="true">
-                <?php
-                $pattern_counter = $per_page > 0 ? (($current_page - 1) * $per_page) : 0;
-                while ($patterns_query->have_posts()):
-                    $patterns_query->the_post();
-                    $pattern_counter++;
-                    $pattern_id = get_the_ID();
+                <?php foreach ($pattern_entries as $entry): ?>
+                    <?php
+                    $terms_display = '';
+                    $term_tokens_attr = '';
 
-                    $raw_title = get_the_title();
-                    if (!is_scalar($raw_title)) {
-                        $raw_title = '';
-                    }
-                    $pattern_title = trim((string) $raw_title);
-                    if ('' === $pattern_title) {
-                        $pattern_title = sprintf(
-                            esc_html__('Composition sans titre #%d', 'theme-export-jlg'),
-                            (int) $pattern_counter
+                    if (!empty($entry['term_labels']) && is_array($entry['term_labels'])) {
+                        $term_badges = array_map(
+                            static function ($label) {
+                                return '<span class="pattern-selection-term">' . esc_html((string) $label) . '</span>';
+                            },
+                            $entry['term_labels']
                         );
+                        $terms_display = implode('', $term_badges);
                     }
 
-                    $raw_excerpt = get_the_excerpt($pattern_id);
-                    if (!is_string($raw_excerpt)) {
-                        $raw_excerpt = '';
-                    }
-                    $excerpt = trim(wp_strip_all_tags($raw_excerpt));
-                    if ('' === $excerpt) {
-                        $raw_content = get_the_content(null, false, $pattern_id);
-                        if (!is_string($raw_content)) {
-                            $raw_content = '';
-                        }
-                        $excerpt = trim(wp_strip_all_tags($raw_content));
-                    }
-                    if ('' !== $excerpt) {
-                        $excerpt = wp_trim_words($excerpt, 30, '…');
+                    if (!empty($entry['term_tokens']) && is_array($entry['term_tokens'])) {
+                        $term_tokens_attr = implode(' ', array_map('sanitize_title', $entry['term_tokens']));
                     }
 
-                    $terms = get_the_terms($pattern_id, 'wp_pattern_category');
-                    $term_badges = [];
-                    $term_tokens = [];
-                    if (is_array($terms) && !is_wp_error($terms)) {
-                        foreach ($terms as $term) {
-                            if (!is_object($term) || !isset($term->name)) {
-                                continue;
-                            }
-                            $term_name = is_scalar($term->name) ? trim((string) $term->name) : '';
-                            $term_slug = isset($term->slug) && is_scalar($term->slug) ? trim((string) $term->slug) : '';
-                            if ('' === $term_name) {
-                                continue;
-                            }
-                            $term_badges[] = sprintf('<span class="pattern-selection-term">%s</span>', esc_html($term_name));
-                            $term_tokens[] = $term_name;
-                            if ('' !== $term_slug) {
-                                $term_tokens[] = $term_slug;
-                            }
-                        }
-                    }
-                    $terms_display = implode('', $term_badges);
-                    $terms_for_data = implode(' ', array_unique($term_tokens));
-
-                    $display_date = get_the_date(get_option('date_format'));
-                    if (!is_string($display_date)) {
-                        $display_date = '';
-                    }
-                    $machine_date = get_the_date('Y-m-d');
-                    if (!is_string($machine_date)) {
-                        $machine_date = '';
-                    }
-                ?>
+                    $search_attr = isset($entry['search_haystack']) ? (string) $entry['search_haystack'] : '';
+                    $date_attr = isset($entry['date_machine']) ? (string) $entry['date_machine'] : '';
+                    $timestamp_attr = isset($entry['timestamp']) ? (string) $entry['timestamp'] : '';
+                    $original_index = isset($entry['display_index']) ? (int) $entry['display_index'] : 0;
+                    ?>
                     <li
-                        class="pattern-selection-item"
-                        data-label="<?php echo esc_attr($pattern_title); ?>"
-                        data-excerpt="<?php echo esc_attr($excerpt); ?>"
-                        data-terms="<?php echo esc_attr($terms_for_data); ?>"
-                        data-date="<?php echo esc_attr($machine_date); ?>"
+                        class="pattern-selection-item pattern-item"
+                        data-label="<?php echo esc_attr($entry['title']); ?>"
+                        data-terms="<?php echo esc_attr($term_tokens_attr); ?>"
+                        data-date="<?php echo esc_attr($date_attr); ?>"
+                        data-timestamp="<?php echo esc_attr($timestamp_attr); ?>"
+                        data-original-index="<?php echo esc_attr($original_index); ?>"
+                        data-search="<?php echo esc_attr($search_attr); ?>"
                     >
-                        <label class="pattern-selection-label">
-                            <input type="checkbox" name="selected_patterns[]" value="<?php echo esc_attr($pattern_id); ?>">
-                            <span class="pattern-selection-content">
-                                <span class="pattern-selection-title"><?php echo esc_html($pattern_title); ?></span>
-                                <?php if ('' !== $display_date || '' !== $terms_display): ?>
-                                    <span class="pattern-selection-meta">
-                                        <?php if ('' !== $display_date): ?>
-                                            <span class="pattern-selection-date"><?php echo esc_html($display_date); ?></span>
-                                        <?php endif; ?>
-                                        <?php if ('' !== $terms_display): ?>
-                                            <span class="pattern-selection-terms" aria-label="<?php echo esc_attr__('Catégories', 'theme-export-jlg'); ?>">
-                                                <?php echo wp_kses_post($terms_display); ?>
-                                            </span>
-                                        <?php endif; ?>
-                                    </span>
-                                <?php endif; ?>
-                                <?php if ('' !== $excerpt): ?>
-                                    <span class="pattern-selection-excerpt"><?php echo esc_html($excerpt); ?></span>
-                                <?php endif; ?>
-                            </span>
-                        </label>
+                        <div class="pattern-selector">
+                            <label>
+                                <input type="checkbox" name="selected_patterns[]" value="<?php echo esc_attr($entry['id']); ?>">
+                                <span class="pattern-selection-content">
+                                    <span class="pattern-selection-title"><?php echo esc_html($entry['title']); ?></span>
+                                    <?php if ('' !== $entry['date_display'] || '' !== $terms_display): ?>
+                                        <span class="pattern-selection-meta">
+                                            <?php if ('' !== $entry['date_display']): ?>
+                                                <span class="pattern-selection-date"><?php echo esc_html($entry['date_display']); ?></span>
+                                            <?php endif; ?>
+                                            <?php if ('' !== $terms_display): ?>
+                                                <span class="pattern-selection-terms" aria-label="<?php echo esc_attr__('Catégories', 'theme-export-jlg'); ?>">
+                                                    <?php echo wp_kses_post($terms_display); ?>
+                                                </span>
+                                            <?php endif; ?>
+                                        </span>
+                                    <?php endif; ?>
+                                    <?php if (!empty($entry['excerpt'])): ?>
+                                        <span class="pattern-selection-excerpt"><?php echo esc_html($entry['excerpt']); ?></span>
+                                    <?php endif; ?>
+                                </span>
+                            </label>
+                        </div>
+                        <div class="pattern-preview-wrapper" data-preview-state="compact">
+                            <div class="pattern-preview-compact" data-preview-compact>
+                                <div class="pattern-preview-compact-thumbnail" aria-hidden="true"></div>
+                                <div class="pattern-preview-compact-details">
+                                    <?php if ('' !== $entry['date_display'] || '' !== $terms_display): ?>
+                                        <div class="pattern-preview-compact-meta">
+                                            <?php if ('' !== $entry['date_display']): ?>
+                                                <span class="pattern-preview-compact-date"><?php echo esc_html($entry['date_display']); ?></span>
+                                            <?php endif; ?>
+                                            <?php if ('' !== $terms_display): ?>
+                                                <span class="pattern-preview-compact-categories" aria-label="<?php echo esc_attr__('Catégories associées', 'theme-export-jlg'); ?>">
+                                                    <?php echo wp_kses_post($terms_display); ?>
+                                                </span>
+                                            <?php endif; ?>
+                                        </div>
+                                    <?php endif; ?>
+                                    <button
+                                        type="button"
+                                        class="button button-secondary pattern-preview-trigger"
+                                        data-preview-trigger="expand"
+                                        aria-controls="<?php echo esc_attr($entry['preview_live_id']); ?>"
+                                        aria-expanded="false"
+                                    >
+                                        <?php esc_html_e('Prévisualiser', 'theme-export-jlg'); ?>
+                                    </button>
+                                </div>
+                            </div>
+                            <div
+                                class="pattern-preview-live"
+                                data-preview-live
+                                id="<?php echo esc_attr($entry['preview_live_id']); ?>"
+                                hidden
+                            >
+                                <button
+                                    type="button"
+                                    class="button-link pattern-preview-trigger pattern-preview-trigger--collapse"
+                                    data-preview-trigger="collapse"
+                                    aria-controls="<?php echo esc_attr($entry['preview_live_id']); ?>"
+                                    aria-expanded="true"
+                                >
+                                    <?php esc_html_e('Masquer la prévisualisation', 'theme-export-jlg'); ?>
+                                </button>
+                                <div class="pattern-preview-loading" data-preview-loading role="status" aria-live="polite" hidden>
+                                    <span class="spinner is-active" aria-hidden="true"></span>
+                                    <span class="pattern-preview-loading-text"><?php esc_html_e('Chargement de la prévisualisation…', 'theme-export-jlg'); ?></span>
+                                </div>
+                                <iframe class="pattern-preview-iframe" title="<?php echo esc_attr($entry['iframe_title']); ?>" sandbox="allow-same-origin" loading="lazy"></iframe>
+                                <div class="pattern-preview-message notice notice-warning" role="status" aria-live="polite" hidden></div>
+                                <script
+                                    type="application/json"
+                                    class="pattern-preview-data"
+                                    data-tejlg-stylesheets="<?php echo esc_attr($entry['stylesheets_json']); ?>"
+                                    data-tejlg-stylesheet-links-html="<?php echo esc_attr($entry['stylesheet_links_json']); ?>"
+                                ><?php echo $entry['iframe_json']; ?></script>
+                            </div>
+                        </div>
                     </li>
-                <?php endwhile; ?>
+                <?php endforeach; ?>
             </ul>
-            <?php wp_reset_postdata(); ?>
             <?php if ($per_page > 0 && $total_pages > 1): ?>
                 <div class="tablenav">
                     <div class="tablenav-pages">


### PR DESCRIPTION
## Summary
- generate preview payloads for export pattern selection and reuse them in the template
- update the export selection markup and styles to embed the interactive preview component
- add an end-to-end test that opens an export preview on demand

## Testing
- npm run test:e2e -- tests/e2e/export-preview.spec.js *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d415fb04832e8e174ce8171d8025