### PR TITLE
Optimize debug pattern summary rendering

### DIFF
--- a/tests/test-admin-debug-page.php
+++ b/tests/test-admin-debug-page.php
@@ -1,0 +1,63 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-admin-debug-page.php';
+
+/**
+ * @group admin
+ */
+class Test_Admin_Debug_Page extends WP_UnitTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        TEJLG_Admin_Debug_Page::invalidate_pattern_summary_cache(0);
+    }
+
+    public function test_pattern_summary_is_cached_between_calls() {
+        $template_dir = dirname(__DIR__) . '/theme-export-jlg/templates/admin/';
+        $debug_page   = new TEJLG_Admin_Debug_Page($template_dir, 'theme-export-jlg');
+
+        $admin_id = self::factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($admin_id);
+
+        $pattern_id = self::factory()->post->create([
+            'post_type'   => 'wp_block',
+            'post_title'  => 'Test Pattern',
+            'post_status' => 'publish',
+            'post_author' => $admin_id,
+        ]);
+
+        update_post_meta($pattern_id, 'wp_block_type', 'pattern');
+
+        TEJLG_Admin_Debug_Page::invalidate_pattern_summary_cache($admin_id);
+
+        $reflection = new ReflectionMethod($debug_page, 'get_custom_patterns_summary');
+        $reflection->setAccessible(true);
+
+        $queries_before_first_call = $GLOBALS['wpdb']->num_queries;
+        $first_summary = $reflection->invoke($debug_page);
+        $queries_after_first_call = $GLOBALS['wpdb']->num_queries;
+
+        $second_summary = $reflection->invoke($debug_page);
+        $queries_after_second_call = $GLOBALS['wpdb']->num_queries;
+
+        $this->assertNotEmpty($first_summary, 'The summary should return at least one pattern.');
+        $this->assertSame($first_summary, $second_summary, 'Cached results should be reused on subsequent calls.');
+        $this->assertSame(
+            $queries_after_first_call,
+            $queries_after_second_call,
+            'No additional database queries should run when using the cached summary.'
+        );
+
+        TEJLG_Admin_Debug_Page::invalidate_pattern_summary_cache($admin_id);
+
+        $queries_after_invalidation = $GLOBALS['wpdb']->num_queries;
+        $third_summary = $reflection->invoke($debug_page);
+
+        $this->assertSame($first_summary, $third_summary, 'Summary contents should remain identical after cache invalidation.');
+        $this->assertGreaterThan(
+            $queries_after_invalidation,
+            $GLOBALS['wpdb']->num_queries,
+            'Cache invalidation should trigger a fresh database query.'
+        );
+    }
+}

--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -917,3 +917,43 @@ textarea.has-pattern-error {
 .tejlg-theme-export-feedback [data-export-download] {
     margin-top: 4px;
 }
+
+.tejlg-custom-patterns-summary {
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+}
+
+.tejlg-custom-patterns-list {
+    margin: 0;
+    padding-left: 1.2em;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.tejlg-custom-patterns-list__item {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    align-items: baseline;
+}
+
+.tejlg-custom-patterns-list__title {
+    font-weight: 600;
+}
+
+.tejlg-custom-patterns-list__slug code {
+    font-family: var(--font-code, SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace);
+}
+
+.tejlg-custom-patterns-list__type {
+    background-color: var(--tejlg-surface-muted-color, #f0f0f1);
+    border-radius: 3px;
+    padding: 0.1rem 0.5rem;
+    font-size: 0.85em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.tejlg-custom-patterns-list__modified time {
+    font-style: italic;
+}

--- a/theme-export-jlg/includes/class-tejlg-import.php
+++ b/theme-export-jlg/includes/class-tejlg-import.php
@@ -959,6 +959,10 @@ class TEJLG_Import {
             )
         );
 
+        if ($imported_count > 0 && class_exists('TEJLG_Admin_Debug_Page')) {
+            TEJLG_Admin_Debug_Page::invalidate_pattern_summary_cache();
+        }
+
         return [
             'imported_count' => $imported_count,
             'errors'         => $errors,


### PR DESCRIPTION
## Summary
- cache the debug pattern summary to avoid repeating expensive queries and expose the cached data to the template
- refresh the custom pattern panel UI with accessible markup and dedicated styles while ensuring the cache is cleared after imports
- cover the new caching layer with a PHPUnit test to guard against regressions

## Testing
- `npm run test:php` *(fails: phpunit not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e35731c1c0832eb4b48d7ece88f3b8