### PR TITLE
Add export duration metadata to history overview

### DIFF
--- a/tests/test-export-history.php
+++ b/tests/test-export-history.php
@@ -21,6 +21,10 @@ class Test_Export_History extends WP_UnitTestCase {
 
         file_put_contents($temp_file, 'demo');
 
+        $start_time     = time() - 120;
+        $update_time    = $start_time + 30;
+        $completed_time = $start_time + 45;
+
         $job = [
             'id'              => 'history-job-1',
             'status'          => 'completed',
@@ -28,9 +32,9 @@ class Test_Export_History extends WP_UnitTestCase {
             'zip_file_name'   => 'history-job-1.zip',
             'zip_file_size'   => filesize($temp_file),
             'exclusions'      => ['node_modules', '*.log'],
-            'created_at'      => time() - 10,
-            'updated_at'      => time() - 5,
-            'completed_at'    => time(),
+            'created_at'      => $start_time,
+            'updated_at'      => $update_time,
+            'completed_at'    => $completed_time,
             'created_by'      => 123,
             'created_by_name' => 'History Tester',
             'created_via'     => 'test',
@@ -50,6 +54,7 @@ class Test_Export_History extends WP_UnitTestCase {
         $this->assertSame('History Tester', $entry['user_name']);
         $this->assertSame(['node_modules', '*.log'], $entry['exclusions']);
         $this->assertSame(filesize($temp_file), $entry['zip_file_size']);
+        $this->assertSame(45, $entry['duration']);
 
         global $wpdb;
         $autoload = $wpdb->get_var(
@@ -75,6 +80,10 @@ class Test_Export_History extends WP_UnitTestCase {
 
         file_put_contents($temp_file, str_repeat('a', 1024));
 
+        $start_time     = time() - 300;
+        $updated_time   = $start_time + 60;
+        $completed_time = $start_time + 75;
+
         $job_id = 'history-job-2';
         $job = [
             'id'              => $job_id,
@@ -83,9 +92,9 @@ class Test_Export_History extends WP_UnitTestCase {
             'zip_file_name'   => 'history-job-2.zip',
             'zip_file_size'   => filesize($temp_file),
             'exclusions'      => ['vendor'],
-            'created_at'      => time() - 20,
-            'updated_at'      => time() - 10,
-            'completed_at'    => time() - 5,
+            'created_at'      => $start_time,
+            'updated_at'      => $updated_time,
+            'completed_at'    => $completed_time,
             'created_by'      => $user_id,
             'created_by_name' => 'History User',
             'created_via'     => 'admin',
@@ -118,6 +127,7 @@ class Test_Export_History extends WP_UnitTestCase {
         $this->assertStringContainsString('history-job-2.zip', $output);
         $this->assertStringContainsString('History User', $output);
         $this->assertStringContainsString('vendor', $output);
+        $this->assertStringContainsString('1 minute 15 secondes', $output);
 
         wp_set_current_user(0);
     }

--- a/theme-export-jlg/includes/class-tejlg-export-history.php
+++ b/theme-export-jlg/includes/class-tejlg-export-history.php
@@ -111,6 +111,39 @@ class TEJLG_Export_History {
             }
         }
 
+        $start_times = [
+            isset($context['start_time']) ? (int) $context['start_time'] : 0,
+            isset($job['started_at']) ? (int) $job['started_at'] : 0,
+            isset($job['created_at']) ? (int) $job['created_at'] : 0,
+        ];
+
+        $start_time = 0;
+
+        foreach ($start_times as $candidate) {
+            if ($candidate > 0) {
+                $start_time = $candidate;
+                break;
+            }
+        }
+
+        $end_times = [
+            isset($context['completed_at']) ? (int) $context['completed_at'] : 0,
+            isset($job['completed_at']) ? (int) $job['completed_at'] : 0,
+            isset($job['updated_at']) ? (int) $job['updated_at'] : 0,
+            $timestamp,
+        ];
+
+        $duration = 0;
+
+        if ($start_time > 0) {
+            foreach ($end_times as $candidate) {
+                if ($candidate >= $start_time) {
+                    $duration = $candidate - $start_time;
+                    break;
+                }
+            }
+        }
+
         $user_id = 0;
 
         if (isset($context['user_id'])) {
@@ -188,6 +221,7 @@ class TEJLG_Export_History {
             'zip_file_size' => max(0, $zip_file_size),
             'exclusions'    => $exclusions,
             'origin'        => $origin,
+            'duration'      => max(0, (int) $duration),
         ];
 
         if (!empty($job['persistent_path']) && is_string($job['persistent_path'])) {
@@ -223,6 +257,7 @@ class TEJLG_Export_History {
         $entry['zip_file_name'] = isset($entry['zip_file_name']) ? sanitize_text_field((string) $entry['zip_file_name']) : '';
         $entry['zip_file_size'] = isset($entry['zip_file_size']) ? max(0, (int) $entry['zip_file_size']) : 0;
         $entry['origin'] = isset($entry['origin']) ? sanitize_key($entry['origin']) : '';
+        $entry['duration'] = isset($entry['duration']) ? max(0, (int) $entry['duration']) : 0;
 
         $exclusions = isset($entry['exclusions']) ? (array) $entry['exclusions'] : [];
         $entry['exclusions'] = array_values(

--- a/theme-export-jlg/templates/admin/export.php
+++ b/theme-export-jlg/templates/admin/export.php
@@ -494,6 +494,7 @@ $history_total_label = number_format_i18n((int) $history_total);
                         <th scope="col"><?php esc_html_e('Tâche', 'theme-export-jlg'); ?></th>
                         <th scope="col"><?php esc_html_e('Utilisateur', 'theme-export-jlg'); ?></th>
                         <th scope="col"><?php esc_html_e('Date', 'theme-export-jlg'); ?></th>
+                        <th scope="col"><?php esc_html_e('Durée', 'theme-export-jlg'); ?></th>
                         <th scope="col"><?php esc_html_e('Taille', 'theme-export-jlg'); ?></th>
                         <th scope="col"><?php esc_html_e('Exclusions', 'theme-export-jlg'); ?></th>
                         <th scope="col"><?php esc_html_e('Statut', 'theme-export-jlg'); ?></th>
@@ -524,6 +525,40 @@ $history_total_label = number_format_i18n((int) $history_total);
                             }
                         }
 
+                        $duration_seconds = isset($entry['duration']) ? (int) $entry['duration'] : 0;
+                        $duration_label   = __('Instantané', 'theme-export-jlg');
+
+                        if ($duration_seconds > 0) {
+                            $duration_parts = [];
+
+                            $hours = (int) floor($duration_seconds / HOUR_IN_SECONDS);
+                            if ($hours > 0) {
+                                $duration_parts[] = sprintf(
+                                    _n('%d heure', '%d heures', $hours, 'theme-export-jlg'),
+                                    $hours
+                                );
+                            }
+
+                            $remaining = $duration_seconds % HOUR_IN_SECONDS;
+                            $minutes   = (int) floor($remaining / MINUTE_IN_SECONDS);
+                            if ($minutes > 0) {
+                                $duration_parts[] = sprintf(
+                                    _n('%d minute', '%d minutes', $minutes, 'theme-export-jlg'),
+                                    $minutes
+                                );
+                            }
+
+                            $seconds = $remaining % MINUTE_IN_SECONDS;
+                            if ($seconds > 0 || empty($duration_parts)) {
+                                $duration_parts[] = sprintf(
+                                    _n('%d seconde', '%d secondes', $seconds, 'theme-export-jlg'),
+                                    $seconds
+                                );
+                            }
+
+                            $duration_label = implode(' ', $duration_parts);
+                        }
+
                         $size_bytes = isset($entry['zip_file_size']) ? (int) $entry['zip_file_size'] : 0;
                         $size_label = $size_bytes > 0 ? size_format($size_bytes, 2) : __('Inconnue', 'theme-export-jlg');
 
@@ -546,6 +581,7 @@ $history_total_label = number_format_i18n((int) $history_total);
                             </td>
                             <td><?php echo esc_html($user_name); ?></td>
                             <td><?php echo esc_html($formatted_date); ?></td>
+                            <td><?php echo esc_html($duration_label); ?></td>
                             <td><?php echo esc_html($size_label); ?></td>
                             <td><?php echo esc_html($exclusions_label); ?></td>
                             <td><?php echo esc_html($status_label); ?></td>


### PR DESCRIPTION
## Summary
- record the time spent on each export job when building history entries
- expose the new duration information in the admin history table with localized formatting
- update the export history tests to cover the new metadata

## Testing
- npm run test:php -- tests/test-export-history.php *(fails: `phpunit` binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4332aa3d8832e978c6cef28c49ecd