### PR TITLE
Add Radix-inspired admin styling

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -1,13 +1,134 @@
 :root {
-    --tejlg-surface-color: var(--wp-components-color-surface, #fff);
-    --tejlg-surface-alt-color: var(--wp-components-color-surface-alt, #f6f7f7);
-    --tejlg-surface-muted-color: var(--wp-components-color-background, #f0f0f1);
-    --tejlg-border-color: var(--wp-components-color-border, #c3c4c7);
-    --tejlg-text-color: var(--wp-components-color-foreground, #1d2327);
-    --tejlg-text-muted-color: var(--wp-components-color-foreground-muted, #50575e);
-    --tejlg-text-subtle-color: var(--wp-components-color-foreground-subtle, #555d66);
-    --tejlg-accent-color: var(--wp-admin-theme-color, #2271b1);
-    --tejlg-accent-color-darker: var(--wp-admin-theme-color-darker-10, #1d4d81);
+    --tejlg-surface-color: var(--wp-components-color-surface, #fdfcfd);
+    --tejlg-surface-alt-color: var(--wp-components-color-surface-alt, #f9f8ff);
+    --tejlg-surface-muted-color: var(--wp-components-color-background, #f4f2ff);
+    --tejlg-border-color: var(--wp-components-color-border, #dcd6f5);
+    --tejlg-border-strong-color: color-mix(in srgb, var(--tejlg-border-color) 75%, #8c7dd1);
+    --tejlg-text-color: var(--wp-components-color-foreground, #1f1729);
+    --tejlg-text-muted-color: var(--wp-components-color-foreground-muted, #6f6a83);
+    --tejlg-text-subtle-color: var(--wp-components-color-foreground-subtle, #807b93);
+    --tejlg-accent-color: var(--wp-admin-theme-color, #6e56cf);
+    --tejlg-accent-color-darker: var(--wp-admin-theme-color-darker-10, #5842c3);
+    --tejlg-accent-color-soft: color-mix(in srgb, var(--tejlg-accent-color) 12%, #ffffff);
+    --tejlg-page-background: radial-gradient(circle at 18% 22%, color-mix(in srgb, var(--tejlg-accent-color) 10%, #ffffff) 0%, transparent 58%),
+        radial-gradient(circle at 82% -6%, color-mix(in srgb, var(--tejlg-accent-color) 12%, #ffffff) 0%, transparent 60%),
+        #f6f5ff;
+    --tejlg-shadow-sm: 0 10px 24px -18px rgba(27, 16, 66, 0.45);
+    --tejlg-shadow-md: 0 18px 36px -24px rgba(41, 24, 96, 0.4), 0 1px 0 rgba(255, 255, 255, 0.65) inset;
+    --tejlg-shadow-lg: 0 32px 60px -38px rgba(36, 20, 83, 0.55);
+    --tejlg-radius-sm: 8px;
+    --tejlg-radius-md: 12px;
+    --tejlg-radius-lg: 16px;
+    --tejlg-radius-xl: 20px;
+}
+
+body.toplevel_page_theme-export-jlg {
+    background: var(--tejlg-page-background);
+    font-family: var(--wp-components-font-family, "Inter", "Inter var", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+    color: var(--tejlg-text-color);
+}
+
+body.toplevel_page_theme-export-jlg #wpcontent,
+body.toplevel_page_theme-export-jlg #wpwrap {
+    background: transparent;
+}
+
+body.toplevel_page_theme-export-jlg #wpbody-content {
+    padding-bottom: 40px;
+}
+
+body.toplevel_page_theme-export-jlg .wrap {
+    position: relative;
+    margin-top: 36px;
+    padding: clamp(2rem, 3vw + 1.25rem, 3.5rem);
+    background: color-mix(in srgb, var(--tejlg-surface-color) 85%, #ffffff);
+    border-radius: var(--tejlg-radius-xl);
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 70%, transparent);
+    box-shadow: var(--tejlg-shadow-lg);
+}
+
+body.toplevel_page_theme-export-jlg .wrap::after {
+    content: "";
+    position: absolute;
+    inset: 12px;
+    pointer-events: none;
+    border-radius: calc(var(--tejlg-radius-xl) - 6px);
+    background: linear-gradient(135deg, color-mix(in srgb, var(--tejlg-accent-color) 9%, transparent), transparent);
+    opacity: 0.75;
+    z-index: 0;
+}
+
+body.toplevel_page_theme-export-jlg .wrap > * {
+    position: relative;
+    z-index: 1;
+}
+
+body.toplevel_page_theme-export-jlg .wrap > h1 {
+    margin-top: 0;
+    margin-bottom: 1.75rem;
+    font-size: clamp(1.8rem, 2vw + 1.2rem, 2.4rem);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+}
+
+body.toplevel_page_theme-export-jlg .nav-tab-wrapper {
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
+    background: color-mix(in srgb, var(--tejlg-surface-alt-color) 92%, transparent);
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 85%, transparent);
+    border-radius: 999px;
+    padding: 6px;
+    margin-bottom: 2.5rem;
+    border-bottom: none;
+    box-shadow: var(--tejlg-shadow-sm);
+}
+
+body.toplevel_page_theme-export-jlg .nav-tab {
+    position: relative;
+    border: none;
+    border-radius: 999px;
+    padding: 8px 18px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--tejlg-text-muted-color);
+    background: transparent;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    line-height: 1.3;
+    box-shadow: none;
+}
+
+body.toplevel_page_theme-export-jlg .nav-tab:hover {
+    color: var(--tejlg-text-color);
+    background: color-mix(in srgb, var(--tejlg-accent-color) 10%, var(--tejlg-surface-alt-color));
+}
+
+body.toplevel_page_theme-export-jlg .nav-tab:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--tejlg-accent-color) 45%, transparent);
+    outline-offset: 2px;
+}
+
+body.toplevel_page_theme-export-jlg .nav-tab.nav-tab-active {
+    color: #fff;
+    background: var(--tejlg-accent-color);
+    box-shadow: 0 16px 26px -22px var(--tejlg-accent-color);
+}
+
+body.toplevel_page_theme-export-jlg .components-card {
+    border-radius: var(--tejlg-radius-lg);
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 80%, transparent);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--tejlg-surface-color) 94%, #ffffff) 0%, var(--tejlg-surface-color) 100%);
+    box-shadow: var(--tejlg-shadow-sm);
+    overflow: hidden;
+}
+
+body.toplevel_page_theme-export-jlg .components-card.is-elevated {
+    box-shadow: var(--tejlg-shadow-md);
+}
+
+body.toplevel_page_theme-export-jlg .components-card__body {
+    padding: clamp(1.25rem, 1vw + 1rem, 1.75rem);
+    gap: 1rem;
 }
 
 /* Style des cartes pour les onglets */
@@ -39,11 +160,20 @@
 }
 
 .tejlg-card {
-    border: 1px solid var(--tejlg-border-color);
-    padding: 0 15px 15px;
-    background: var(--tejlg-surface-color);
-    box-shadow: var(--wp-components-elevation-1, 0 1px 1px rgba(0, 0, 0, 0.04));
-    border-radius: var(--wp-admin-border-radius, 4px);
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 80%, transparent);
+    padding: clamp(1.25rem, 1vw + 1rem, 1.75rem);
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--tejlg-surface-color) 90%, #ffffff) 0%, color-mix(in srgb, var(--tejlg-surface-alt-color) 98%, #ffffff) 100%);
+    box-shadow: var(--tejlg-shadow-sm);
+    border-radius: var(--tejlg-radius-lg);
+    transition: border-color 0.2s ease, box-shadow 0.25s ease, transform 0.2s ease;
+}
+
+.tejlg-card:hover,
+.tejlg-card:focus-within {
+    border-color: color-mix(in srgb, var(--tejlg-accent-color) 35%, var(--tejlg-border-color));
+    box-shadow: var(--tejlg-shadow-md);
+    transform: translateY(-1px);
 }
 
 .tejlg-card--primary {
@@ -55,18 +185,20 @@
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-    padding: 1.25rem;
-    margin: 0 0 1rem;
-    border: 2px dashed var(--tejlg-border-color);
-    border-radius: var(--wp-admin-border-radius, 4px);
-    background-color: var(--tejlg-surface-alt-color);
+    padding: 1.5rem;
+    margin: 0 0 1.1rem;
+    border: 1px dashed color-mix(in srgb, var(--tejlg-border-color) 80%, transparent);
+    border-radius: var(--tejlg-radius-md);
+    background: color-mix(in srgb, var(--tejlg-accent-color-soft) 70%, var(--tejlg-surface-alt-color));
     cursor: pointer;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
     transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
 .tejlg-dropzone:hover {
-    border-color: color-mix(in srgb, var(--tejlg-accent-color) 40%, var(--tejlg-border-color));
-    background-color: color-mix(in srgb, var(--tejlg-accent-color) 6%, var(--tejlg-surface-alt-color));
+    border-color: color-mix(in srgb, var(--tejlg-accent-color) 45%, var(--tejlg-border-color));
+    background-color: color-mix(in srgb, var(--tejlg-accent-color) 12%, var(--tejlg-surface-alt-color));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tejlg-accent-color) 24%, transparent);
 }
 
 .tejlg-dropzone:focus-visible {
@@ -76,8 +208,8 @@
 
 .tejlg-dropzone.is-dragover {
     border-color: var(--tejlg-accent-color);
-    background-color: color-mix(in srgb, var(--tejlg-accent-color) 8%, var(--tejlg-surface-alt-color));
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tejlg-accent-color) 30%, transparent);
+    background-color: color-mix(in srgb, var(--tejlg-accent-color) 18%, var(--tejlg-accent-color-soft));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tejlg-accent-color) 45%, transparent), 0 16px 26px -28px var(--tejlg-accent-color);
 }
 
 .tejlg-dropzone__content {
@@ -147,10 +279,11 @@
 }
 
 .tejlg-pattern-test__list {
-    background: var(--tejlg-surface-alt-color);
-    border: 1px solid var(--tejlg-border-color);
-    border-radius: var(--wp-admin-border-radius, 4px);
-    padding: 0.75rem;
+    background: color-mix(in srgb, var(--tejlg-surface-alt-color) 88%, #ffffff);
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 75%, transparent);
+    border-radius: var(--tejlg-radius-md);
+    padding: 0.9rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 .tejlg-pattern-test__list h4 {
@@ -591,11 +724,13 @@ textarea.has-pattern-error {
     width: 100%;
     min-height: 250px;
     height: auto;
-    border: 1px dashed var(--tejlg-border-color);
-    background: var(--tejlg-surface-color);
+    border: 1px dashed color-mix(in srgb, var(--tejlg-border-color) 75%, transparent);
+    background: color-mix(in srgb, var(--tejlg-surface-color) 92%, #ffffff);
     max-width: var(--tejlg-preview-max-width, 960px);
     margin-inline: auto;
     display: block;
+    border-radius: var(--tejlg-radius-md);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .pattern-preview-message {
@@ -611,10 +746,9 @@ textarea.has-pattern-error {
     gap: 12px;
     margin: 12px 0;
     padding: 16px 18px;
-    border: 2px dashed var(--tejlg-accent-color);
-    border-radius: var(--wp-admin-border-radius, 8px);
-    background-color: var(--tejlg-surface-muted-color);
-    background-color: color-mix(in srgb, var(--tejlg-accent-color) 12%, transparent);
+    border: 2px dashed color-mix(in srgb, var(--tejlg-accent-color) 65%, var(--tejlg-border-strong-color));
+    border-radius: var(--tejlg-radius-lg);
+    background-color: color-mix(in srgb, var(--tejlg-accent-color) 12%, var(--tejlg-surface-muted-color));
     color: var(--tejlg-accent-color-darker);
     font-size: 14px;
     line-height: 1.5;
@@ -744,21 +878,22 @@ textarea.has-pattern-error {
 
 /* Styles pour la page de sélection des compositions à exporter */
 .pattern-selection-list {
-    background: var(--tejlg-surface-color);
-    border: 1px solid var(--tejlg-border-color);
-    padding: 1px 1.5rem;
-    margin-top: 1rem;
-    max-width: 600px;
+    background: linear-gradient(180deg, color-mix(in srgb, var(--tejlg-surface-color) 96%, #ffffff) 0%, color-mix(in srgb, var(--tejlg-surface-alt-color) 92%, #ffffff) 100%);
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 75%, transparent);
+    padding: clamp(1.25rem, 1vw + 1rem, 1.75rem);
+    margin-top: 1.25rem;
+    max-width: 640px;
+    border-radius: var(--tejlg-radius-lg);
+    box-shadow: var(--tejlg-shadow-sm);
 }
 
 .pattern-selection-list .select-all-wrapper {
-    border-bottom: 1px solid var(--tejlg-border-color);
     border-bottom: 1px solid color-mix(in srgb, var(--tejlg-border-color) 80%, transparent);
     padding-bottom: 1rem;
 }
 
 .pattern-selection-search {
-    margin: 1rem 0;
+    margin: 1.25rem 0;
 }
 
 #pattern-search {
@@ -782,16 +917,17 @@ textarea.has-pattern-error {
 }
 
 .pattern-selection-list ul {
-    border: 1px solid var(--tejlg-border-color);
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 70%, transparent);
     padding: 1rem;
     margin-bottom: 1rem;
-    background: var(--tejlg-surface-color);
+    background: color-mix(in srgb, var(--tejlg-surface-color) 90%, #ffffff);
+    border-radius: var(--tejlg-radius-md);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 @media (max-width: 782px) {
     .pattern-selection-list {
-        padding-left: 0.75rem;
-        padding-right: 0.75rem;
+        padding: 1rem;
     }
 
     #pattern-selection-items {
@@ -803,8 +939,7 @@ textarea.has-pattern-error {
 .pattern-selection-list li {
     list-style: none;
     margin: 0;
-    padding: 0.75rem 0;
-    border-bottom: 1px solid var(--tejlg-border-color);
+    padding: 0.9rem 0;
     border-bottom: 1px solid color-mix(in srgb, var(--tejlg-border-color) 90%, transparent);
 }
 
@@ -836,10 +971,18 @@ textarea.has-pattern-error {
     align-items: flex-start;
     gap: 12px;
     cursor: pointer;
+    padding: 0.4rem 0.35rem;
+    border-radius: var(--tejlg-radius-sm);
+    transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .pattern-selection-label input[type="checkbox"] {
     margin-top: 3px;
+}
+
+.pattern-selection-label:hover {
+    background: color-mix(in srgb, var(--tejlg-accent-color) 8%, transparent);
+    transform: translateX(2px);
 }
 
 .pattern-selection-content {
@@ -863,8 +1006,8 @@ textarea.has-pattern-error {
 }
 
 .pattern-selection-date {
-    background: var(--tejlg-surface-muted-color);
-    border-radius: var(--wp-admin-border-radius, 999px);
+    background: color-mix(in srgb, var(--tejlg-accent-color) 10%, var(--tejlg-surface-muted-color));
+    border-radius: 999px;
     padding: 2px 10px;
     line-height: 1.6;
 }
@@ -876,13 +1019,13 @@ textarea.has-pattern-error {
 }
 
 .pattern-selection-term {
-    background: var(--tejlg-accent-color);
-    color: var(--tejlg-surface-color);
-    border-radius: var(--wp-admin-border-radius, 999px);
+    background: color-mix(in srgb, var(--tejlg-accent-color) 25%, var(--tejlg-accent-color-soft));
+    color: var(--tejlg-accent-color-darker);
+    border-radius: 999px;
     padding: 2px 10px;
     font-size: 11px;
     line-height: 1.6;
-    font-weight: 500;
+    font-weight: 600;
 }
 
 .pattern-selection-excerpt {
@@ -967,55 +1110,65 @@ textarea.has-pattern-error {
 }
 
 .tejlg-dashboard {
-    margin-top: 1.5rem;
+    margin-top: 2rem;
+    display: grid;
+    gap: 2rem;
 }
 
 .tejlg-dashboard__header {
-    margin-bottom: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
 }
 
 .tejlg-dashboard__intro {
-    margin: 0.25rem 0 0;
+    margin: 0;
+    max-width: 52ch;
     color: var(--tejlg-text-muted-color);
+    font-size: 0.98em;
 }
 
 .tejlg-dashboard__grid {
     display: grid;
-    gap: 16px;
+    gap: 20px;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .tejlg-dashboard__card .components-card__body {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.5rem;
 }
 
 .tejlg-dashboard__label {
     font-size: 11px;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
     color: var(--tejlg-text-muted-color);
 }
 
 .tejlg-dashboard__value {
-    font-size: 1.1em;
-    font-weight: 600;
+    font-size: 1.2em;
+    font-weight: 650;
     color: var(--tejlg-text-color);
 }
 
 .tejlg-dashboard__meta {
     color: var(--tejlg-text-subtle-color);
-    font-size: 0.92em;
+    font-size: 0.95em;
 }
 
 .tejlg-stepper {
     list-style: none;
-    margin: 1.5rem 0 1rem;
-    padding: 0;
+    margin: 1.75rem 0 1.25rem;
+    padding: 12px;
     display: flex;
     gap: 12px;
     flex-wrap: wrap;
+    background: color-mix(in srgb, var(--tejlg-surface-alt-color) 70%, transparent);
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 65%, transparent);
+    border-radius: var(--tejlg-radius-lg);
 }
 
 .tejlg-stepper__step {
@@ -1024,22 +1177,26 @@ textarea.has-pattern-error {
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 12px 16px;
-    border: 1px solid var(--tejlg-border-color);
-    border-radius: var(--wp-admin-border-radius, 6px);
-    background: var(--tejlg-surface-alt-color);
+    padding: 14px 18px;
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 80%, transparent);
+    border-radius: var(--tejlg-radius-md);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--tejlg-surface-color) 92%, #ffffff) 0%, var(--tejlg-surface-alt-color) 100%);
     position: relative;
-    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .tejlg-stepper__step.is-active {
-    border-color: var(--tejlg-accent-color);
-    background: color-mix(in srgb, var(--tejlg-accent-color) 10%, var(--tejlg-surface-alt-color));
+    border-color: color-mix(in srgb, var(--tejlg-accent-color) 55%, var(--tejlg-border-color));
+    background: color-mix(in srgb, var(--tejlg-accent-color) 20%, var(--tejlg-accent-color-soft));
+    box-shadow: 0 18px 32px -28px var(--tejlg-accent-color);
+    transform: translateY(-1px);
 }
 
 .tejlg-stepper__step.is-complete {
-    border-color: color-mix(in srgb, var(--tejlg-accent-color) 55%, var(--tejlg-border-color));
-    background: color-mix(in srgb, var(--tejlg-accent-color) 18%, var(--tejlg-surface-alt-color));
+    border-color: color-mix(in srgb, var(--tejlg-accent-color) 45%, var(--tejlg-border-color));
+    background: color-mix(in srgb, var(--tejlg-accent-color) 14%, var(--tejlg-accent-color-soft));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tejlg-accent-color) 18%, transparent);
 }
 
 .tejlg-stepper__index {
@@ -1048,21 +1205,25 @@ textarea.has-pattern-error {
     justify-content: center;
     width: 28px;
     height: 28px;
-    border-radius: 50%;
-    background: var(--tejlg-surface-color);
-    border: 1px solid var(--tejlg-border-color);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--tejlg-accent-color-soft) 80%, var(--tejlg-surface-color));
+    border: 1px solid color-mix(in srgb, var(--tejlg-border-color) 70%, transparent);
+    color: color-mix(in srgb, var(--tejlg-accent-color) 55%, var(--tejlg-text-color));
     font-weight: 600;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
 }
 
 .tejlg-stepper__step.is-active .tejlg-stepper__index,
 .tejlg-stepper__step.is-complete .tejlg-stepper__index {
     border-color: var(--tejlg-accent-color);
-    color: var(--tejlg-accent-color);
+    background: var(--tejlg-accent-color);
+    color: #fff;
 }
 
 .tejlg-stepper__label {
     font-weight: 600;
     color: var(--tejlg-text-color);
+    line-height: 1.4;
 }
 
 .tejlg-steps {
@@ -1087,7 +1248,7 @@ textarea.has-pattern-error {
 
 .tejlg-step__details {
     display: grid;
-    gap: 0.75rem;
+    gap: 0.85rem;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     margin: 0;
 }


### PR DESCRIPTION
## Summary
- introduce Radix UI-inspired design tokens and layout for the Theme Export admin page
- restyle cards, dropzones, dashboard, and stepper with gradient surfaces and accent focus states
- refresh pattern selection and preview surfaces to match the new visual language

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e54f109440832ebf4591664be51f5d