### PR TITLE
Scope mobile nav tab styles to plugin page

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -149,7 +149,7 @@ body.toplevel_page_theme-export-jlg .components-card__body {
         margin-inline: 10px;
     }
 
-    .nav-tab-wrapper {
+    body.toplevel_page_theme-export-jlg .nav-tab-wrapper {
         display: flex;
         flex-wrap: wrap;
         gap: 8px;


### PR DESCRIPTION
## Summary
- scope the mobile navigation tab wrapper styles so they only affect the Theme Export admin screen

## Testing
- not run (WordPress test environment not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e551fe66e4832ea55e2148dd6f3841