### PR TITLE
Add CSS fallbacks for color-mix and document review

### DIFF
--- a/docs/code-review-20240524.md
+++ b/docs/code-review-20240524.md
@@ -1,0 +1,31 @@
+# Revue du code Theme Export – JLG (24 mai 2024)
+
+## Points forts
+- Architecture orientée objets : les classes `TEJLG_Admin_*` encapsulent bien les responsabilités (enregistrement du menu, rendu des écrans, traitement des formulaires), ce qui facilite l’extension et les tests unitaires ciblés.
+- Sécurité : chaque action critique vérifie les capacités (ex. `TEJLG_Capabilities::current_user_can('exports')`) et les formulaires utilisent des nonces (`wp_verify_nonce` / `wp_create_nonce`).
+- Accessibilité & UX : l’interface admin exploite les composants WordPress (`components-card`, classes `wp-ui-*`) et les scripts localisés exposent des libellés internationalisés et des attributs ARIA (`aria-live`, `aria-atomic`).
+
+## Risques et axes d’amélioration
+1. **Compatibilité CSS (color-mix)**  
+   La feuille `assets/css/admin-styles.css` utilise massivement `color-mix()`. Les navigateurs antérieurs (Safari < 15.4, Chrome < 111) ignorent cette fonction et annulent la déclaration entière, ce qui peut laisser des fonds transparents ou des bordures absentes.  
+   → Solution implémentée : ajout de fallbacks dans un bloc `@supports not (color: color-mix(...))` et séparation du fond en `background-color`/`background-image` pour conserver une mise en page lisible sans `color-mix()`.
+
+2. **Surveillance des fichiers volumineux**  
+   `assets/js/admin-scripts.js` dépasse 3 000 lignes. L’absence de découpage en modules ou en sous-fichiers rend la maintenance plus délicate (risque d’effets de bord lors des modifications).  
+   → Recommandation : migrer progressivement vers des modules ES (via un bundler ou `@wordpress/scripts`) pour segmenter les responsabilités (dropzones, pattern tester, file d’attente d’exports…).
+
+3. **Gestion des erreurs asynchrones**  
+   Les appels AJAX de la file d’export gèrent bien les messages (`failed`, `unknownError`). En revanche, aucune stratégie de retry progressif n’est prévue et un simple `fetch` échoué stoppe le processus.  
+   → Recommandation : introduire un backoff exponentiel (2–3 tentatives) et enregistrer l’échec côté PHP afin de nourrir l’historique (`TEJLG_Export_History`).
+
+4. **Journalisation enrichie**  
+   `TEJLG_Export_History::record_job()` stocke déjà les métadonnées basiques. Il serait pertinent d’y ajouter la taille finale de l’archive, la durée d’exécution et l’utilisateur initiateur pour alimenter des rapports ou notifications futures.  
+   → Ceci faciliterait la mise en place de notifications (e-mail/webhook) évoquées dans `docs/roadmap.md`.
+
+5. **Tests automatisés**  
+   Le dépôt expose des scripts `npm run test:php` et `npm run test:e2e`, mais aucun bootstrap PHPUnit ou configuration Playwright n’est fourni.  
+   → Clarifier dans la documentation comment installer l’environnement de test (WordPress de démo, configuration Playwright, etc.) ou fournir des mocks pour lancer les suites en CI.
+
+## Suivi
+- Prioriser la factorisation de `admin-scripts.js` lors d’une future évolution majeure.
+- Documenter les navigateurs officiellement supportés dans le readme (section « Prérequis ») afin de cadrer les attentes côté clients.

--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -22,8 +22,52 @@
     --tejlg-radius-xl: 20px;
 }
 
+@supports not (color: color-mix(in srgb, #000 50%, #fff 50%)) {
+    body.toplevel_page_theme-export-jlg {
+        background: #f6f5ff;
+    }
+
+    body.toplevel_page_theme-export-jlg .wrap {
+        background: #ffffff;
+        border: 1px solid var(--tejlg-border-color);
+        box-shadow: var(--tejlg-shadow-lg);
+    }
+
+    body.toplevel_page_theme-export-jlg .nav-tab-wrapper {
+        background: #f3f0ff;
+        border: 1px solid var(--tejlg-border-color);
+    }
+
+    body.toplevel_page_theme-export-jlg .components-card,
+    .tejlg-card {
+        background: #ffffff;
+        border: 1px solid var(--tejlg-border-color);
+    }
+
+    .tejlg-dropzone {
+        background: #f4f1ff;
+        border-color: var(--tejlg-border-color);
+    }
+
+    .tejlg-dropzone:hover,
+    .tejlg-dropzone:focus-visible {
+        background: #ede6ff;
+        border-color: var(--tejlg-accent-color);
+    }
+
+    .tejlg-card:hover,
+    .tejlg-card:focus-within {
+        border-color: var(--tejlg-accent-color);
+    }
+}
+
 body.toplevel_page_theme-export-jlg {
-    background: var(--tejlg-page-background);
+    background-color: #f6f5ff;
+    background-image: radial-gradient(circle at 18% 22%, color-mix(in srgb, var(--tejlg-accent-color) 10%, #ffffff) 0%, transparent 58%),
+        radial-gradient(circle at 82% -6%, color-mix(in srgb, var(--tejlg-accent-color) 12%, #ffffff) 0%, transparent 60%);
+    background-blend-mode: normal;
+    background-repeat: no-repeat;
+    background-size: cover;
     font-family: var(--wp-components-font-family, "Inter", "Inter var", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
     color: var(--tejlg-text-color);
 }


### PR DESCRIPTION
## Summary
- add a defensive CSS block to restore readable backgrounds/borders when color-mix() is not supported
- split the body background into color and image layers so legacy browsers keep a solid fill
- document the audit in docs/code-review-20240524.md with follow-up recommendations

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e5638713e8832e8865ca3f03f83307