### PR TITLE
feat: enrich export history insights

### DIFF
--- a/theme-export-jlg/assets/css/admin-styles.css
+++ b/theme-export-jlg/assets/css/admin-styles.css
@@ -361,6 +361,129 @@ body.toplevel_page_theme-export-jlg .components-card__body {
     font-weight: 600;
 }
 
+.tejlg-history-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 1.5rem;
+    align-items: flex-end;
+    margin: 0 0 1.25rem;
+}
+
+.tejlg-history-filters__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 180px;
+}
+
+.tejlg-history-filters__group label {
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--tejlg-text-muted-color);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.tejlg-history-filters__group select,
+.tejlg-history-filters__group input,
+.tejlg-history-filters__actions .button {
+    max-width: 240px;
+}
+
+.tejlg-history-filters__actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-left: auto;
+    align-items: center;
+}
+
+.tejlg-history-summary {
+    margin: 0 0 1rem;
+    color: var(--tejlg-text-muted-color);
+    font-size: 13px;
+}
+
+.tejlg-history-origin {
+    display: block;
+    font-weight: 600;
+}
+
+.tejlg-history-origin__context {
+    display: block;
+    margin-top: 0.2rem;
+    color: var(--tejlg-text-muted-color);
+    font-size: 12px;
+}
+
+.tejlg-history-status {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.15rem 0.65rem;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.5;
+    letter-spacing: 0.01em;
+    border: 1px solid transparent;
+    background: color-mix(in srgb, var(--tejlg-accent-color) 12%, transparent);
+    color: var(--tejlg-accent-color);
+}
+
+.tejlg-history-status__message {
+    display: block;
+    margin-top: 0.35rem;
+    font-size: 12px;
+    color: var(--tejlg-text-muted-color);
+    max-width: 22rem;
+}
+
+.tejlg-history-status--success {
+    background: color-mix(in srgb, #2f855a 18%, transparent);
+    color: #1f543a;
+    border-color: color-mix(in srgb, #2f855a 35%, transparent);
+}
+
+.tejlg-history-status--warning {
+    background: color-mix(in srgb, #dd6b20 20%, transparent);
+    color: #8a4614;
+    border-color: color-mix(in srgb, #dd6b20 32%, transparent);
+}
+
+.tejlg-history-status--error {
+    background: color-mix(in srgb, #c53030 18%, transparent);
+    color: #7f1b1b;
+    border-color: color-mix(in srgb, #c53030 30%, transparent);
+}
+
+.tejlg-history-status--info {
+    background: color-mix(in srgb, var(--tejlg-accent-color) 14%, transparent);
+    color: var(--tejlg-accent-color-darker);
+    border-color: color-mix(in srgb, var(--tejlg-accent-color) 28%, transparent);
+}
+
+.tejlg-history-status--neutral {
+    background: color-mix(in srgb, var(--tejlg-border-color) 35%, transparent);
+    color: var(--tejlg-text-muted-color);
+    border-color: color-mix(in srgb, var(--tejlg-border-color) 48%, transparent);
+}
+
+@media (max-width: 782px) {
+    .tejlg-history-filters {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .tejlg-history-filters__actions {
+        margin-left: 0;
+        justify-content: flex-start;
+    }
+
+    .tejlg-history-status__message {
+        max-width: 100%;
+    }
+}
+
 textarea.has-pattern-error {
     border-color: #dc3232;
     box-shadow: 0 0 0 1px rgba(220, 50, 50, 0.2);

--- a/theme-export-jlg/includes/class-tejlg-admin-export-page.php
+++ b/theme-export-jlg/includes/class-tejlg-admin-export-page.php
@@ -155,10 +155,26 @@ class TEJLG_Admin_Export_Page extends TEJLG_Admin_Page {
         $history_page = isset($_GET['history_page']) ? absint($_GET['history_page']) : 0;
         $history_page = $history_page > 0 ? $history_page : 1;
 
+        $history_result = isset($_GET['history_result']) ? sanitize_key((string) $_GET['history_result']) : '';
+        $history_origin = isset($_GET['history_origin']) ? sanitize_key((string) $_GET['history_origin']) : '';
+        $history_orderby = isset($_GET['history_orderby']) ? sanitize_key((string) $_GET['history_orderby']) : 'timestamp';
+        $allowed_history_orderby = ['timestamp', 'duration', 'zip_file_size'];
+        if (!in_array($history_orderby, $allowed_history_orderby, true)) {
+            $history_orderby = 'timestamp';
+        }
+        $history_order = isset($_GET['history_order']) ? strtolower((string) $_GET['history_order']) : 'desc';
+        $history_order = 'asc' === $history_order ? 'asc' : 'desc';
+
         $history = TEJLG_Export_History::get_entries([
             'per_page' => $history_per_page,
             'paged'    => $history_page,
+            'result'   => $history_result,
+            'origin'   => $history_origin,
+            'orderby'  => $history_orderby,
+            'order'    => $history_order,
         ]);
+
+        $history_filters = TEJLG_Export_History::get_available_filters();
 
         $history_total_pages = isset($history['total_pages']) ? (int) $history['total_pages'] : 1;
         $history_total_pages = $history_total_pages > 0 ? $history_total_pages : 1;
@@ -187,10 +203,22 @@ class TEJLG_Admin_Export_Page extends TEJLG_Admin_Page {
             'schedule_next_run'         => $schedule_next_run,
             'history_entries'           => isset($history['entries']) ? (array) $history['entries'] : [],
             'history_total'             => isset($history['total']) ? (int) $history['total'] : 0,
+            'history_total_all'         => TEJLG_Export_History::count_entries(),
             'history_pagination_links'  => is_array($history_pagination_links) ? $history_pagination_links : [],
             'history_current_page'      => isset($history['current_page']) ? (int) $history['current_page'] : 1,
             'history_total_pages'       => $history_total_pages,
             'history_per_page'          => $history_per_page,
+            'history_filter_values'     => $history_filters,
+            'history_selected_filters'  => [
+                'result'  => $history_result,
+                'origin'  => $history_origin,
+                'orderby' => $history_orderby,
+                'order'   => $history_order,
+            ],
+            'history_base_args'         => [
+                'page' => $this->page_slug,
+                'tab'  => 'export',
+            ],
         ]);
     }
 


### PR DESCRIPTION
## Summary
- classify export jobs with result metadata, context and hookable notifications before persisting history entries
- expose filtering, sorting and richer status/origin details in the export history admin table with refreshed styling
- propagate user-selected filters and totals from the export admin page to the template

## Testing
- php -l theme-export-jlg/includes/class-tejlg-export-history.php
- php -l theme-export-jlg/includes/class-tejlg-admin-export-page.php
- php -l theme-export-jlg/templates/admin/export.php

------
https://chatgpt.com/codex/tasks/task_e_68e5764c4908832e80b9ab96a1c24654