### PR TITLE
Add CLI history filters and document code review insights

### DIFF
--- a/docs/code-review-2024-11-29.md
+++ b/docs/code-review-2024-11-29.md
@@ -1,0 +1,13 @@
+# Revue de code du plugin Theme Export JLG
+
+## Points forts
+- La classe `TEJLG_Export` applique systématiquement des normalisations et contrôles d'erreurs lors de la constitution des archives, ce qui limite les risques de parcours de répertoires et d'injections de chemins. Les fonctions `normalize_path()` et `should_exclude_file()` contribuent à sécuriser le processus d'exclusion des fichiers.
+- L'historique des exports (`TEJLG_Export_History`) conserve des entrées normalisées et expose des filtres (`tejlg_export_history_entry`, `tejlg_export_history_max_entries`) facilitant l'extension par des thèmes ou extensions tierces.
+
+## Améliorations intégrées
+- Le CLI dispose désormais de filtres `--result` et `--origin` pour cibler rapidement un sous-ensemble d'exports, ce qui facilite l'exploitation des environnements de production et le diagnostic d'incidents.
+
+## Opportunités supplémentaires
+- `TEJLG_Export::persist_export_archive()` retourne silencieusement un tableau vide en cas d'échec de création de dossier ou de copie. Journaliser ces erreurs (via `error_log()` ou une action dédiée) simplifierait le diagnostic en production.
+- `TEJLG_Export_Process::task()` ferme l'archive ZIP avant tout retour mais ne journalise pas la raison exacte d'un échec d'ajout dans l'archive. Un appel à `error_log()` ou à un hook pourrait aider à identifier les fichiers problématiques.
+- Les commandes CLI pourraient proposer un format de sortie alternatif (JSON, CSV) pour faciliter l'automatisation ou l'intégration avec d'autres outils.

--- a/theme-export-jlg/includes/class-tejlg-cli.php
+++ b/theme-export-jlg/includes/class-tejlg-cli.php
@@ -20,7 +20,7 @@ class TEJLG_CLI {
         WP_CLI::log('  wp theme-export-jlg patterns [--portable] [--output=<chemin>]');
         WP_CLI::log('  wp theme-export-jlg import theme <chemin_zip> [--overwrite]');
         WP_CLI::log('  wp theme-export-jlg import patterns <chemin_json>');
-        WP_CLI::log('  wp theme-export-jlg history [--per-page=<nombre>] [--page=<nombre>]');
+        WP_CLI::log('  wp theme-export-jlg history [--per-page=<nombre>] [--page=<nombre>] [--result=<statut>] [--origin=<origine>]');
         WP_CLI::log('  wp theme-export-jlg settings export [--output=<chemin>]');
         WP_CLI::log('  wp theme-export-jlg settings import <chemin_json>');
     }
@@ -114,9 +114,14 @@ class TEJLG_CLI {
         $page = isset($assoc_args['page']) ? (int) $assoc_args['page'] : 1;
         $page = $page > 0 ? $page : 1;
 
+        $result_filter = isset($assoc_args['result']) ? sanitize_key((string) $assoc_args['result']) : '';
+        $origin_filter = isset($assoc_args['origin']) ? sanitize_key((string) $assoc_args['origin']) : '';
+
         $history = TEJLG_Export_History::get_entries([
             'per_page' => $per_page,
             'paged'    => $page,
+            'result'   => $result_filter,
+            'origin'   => $origin_filter,
         ]);
 
         $entries = isset($history['entries']) ? (array) $history['entries'] : [];
@@ -125,7 +130,11 @@ class TEJLG_CLI {
         $total_pages = $total_pages > 0 ? $total_pages : 1;
 
         if (empty($entries)) {
-            WP_CLI::log(__('Aucun export n\'a encore été enregistré.', 'theme-export-jlg'));
+            if ('' !== $result_filter || '' !== $origin_filter) {
+                WP_CLI::log(__('Aucun export ne correspond aux filtres fournis.', 'theme-export-jlg'));
+            } else {
+                WP_CLI::log(__('Aucun export n\'a encore été enregistré.', 'theme-export-jlg'));
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary
- add --result and --origin filters to the WP-CLI history command and improve its empty-state messaging
- extend CLI tests with log capture and coverage for the new filters
- document the current review, strengths, and follow-up opportunities for the plugin

## Testing
- npm run test:php *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e63a17d8cc832e890addf65c594b22