### PR TITLE
Fix root-level export directory entries

### DIFF
--- a/tests/test-export-process.php
+++ b/tests/test-export-process.php
@@ -1,0 +1,103 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export-process.php';
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-zip-writer.php';
+
+class TEJLG_Export_Process_Test_Double extends TEJLG_Export_Process {
+    public function public_task($item) {
+        return $this->task($item);
+    }
+}
+
+/**
+ * @group export-theme
+ */
+class Test_Export_Process extends WP_UnitTestCase {
+
+    public function test_root_level_files_do_not_create_dot_directories_in_zip() {
+        $job_id = sanitize_key('tejlg-process-' . wp_generate_uuid4());
+        $zip_path = wp_tempnam('tejlg-process-zip');
+
+        $this->assertIsString($zip_path, 'A temporary ZIP path should be generated.');
+        $this->assertNotEmpty($zip_path, 'The temporary ZIP path should not be empty.');
+
+        $writer = TEJLG_Zip_Writer::create($zip_path);
+        $this->assertNotWPError($writer, 'The ZIP writer should initialize successfully.');
+
+        if ($writer instanceof TEJLG_Zip_Writer) {
+            $writer->close();
+        }
+
+        $job_payload = [
+            'id'                => $job_id,
+            'status'            => 'processing',
+            'zip_path'          => $zip_path,
+            'directories_added' => [],
+            'processed_items'   => 0,
+            'total_items'       => 1,
+            'created_at'        => time(),
+            'updated_at'        => time(),
+        ];
+
+        TEJLG_Export::persist_job($job_payload);
+
+        $file_path = wp_tempnam('tejlg-process-file');
+        $this->assertIsString($file_path, 'A temporary file path should be created.');
+        file_put_contents($file_path, 'Example content');
+
+        $process = new TEJLG_Export_Process_Test_Double();
+        $process->public_task([
+            'job_id'               => $job_id,
+            'type'                 => 'file',
+            'real_path'            => $file_path,
+            'relative_path_in_zip' => 'style.css',
+        ]);
+
+        $job_after = TEJLG_Export::get_job($job_id);
+        $this->assertIsArray($job_after, 'The job should still be stored after processing.');
+        $this->assertSame('completed', isset($job_after['status']) ? $job_after['status'] : '', 'Processing the last item should finalize the job.');
+
+        $entries = [];
+
+        if (class_exists('ZipArchive')) {
+            $zip = new ZipArchive();
+            $this->assertSame(true, $zip->open($zip_path), 'The generated archive should open with ZipArchive.');
+
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $entries[] = $zip->getNameIndex($i);
+            }
+
+            $zip->close();
+        } else {
+            if (!class_exists('PclZip')) {
+                require_once ABSPATH . 'wp-admin/includes/class-pclzip.php';
+            }
+
+            $pclzip = new PclZip($zip_path);
+            $list   = $pclzip->listContent();
+
+            $this->assertIsArray($list, 'PclZip should return the archive contents.');
+
+            foreach ($list as $entry) {
+                if (isset($entry['stored_filename'])) {
+                    $entries[] = $entry['stored_filename'];
+                } elseif (isset($entry['filename'])) {
+                    $entries[] = $entry['filename'];
+                }
+            }
+        }
+
+        $this->assertNotEmpty($entries, 'The archive should contain at least one entry.');
+        $this->assertContains('style.css', $entries, 'The root-level file should be present in the archive.');
+
+        foreach ($entries as $entry_name) {
+            $normalized = rtrim((string) $entry_name, '/');
+            $this->assertNotSame('.', $normalized, 'The archive should not contain a \'./\' directory entry.');
+        }
+
+        TEJLG_Export::delete_job($job_id);
+        @unlink($zip_path);
+        @unlink($file_path);
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-export-process.php
+++ b/theme-export-jlg/includes/class-tejlg-export-process.php
@@ -108,17 +108,28 @@ class TEJLG_Export_Process extends WP_Background_Process {
                 return false;
             }
 
-            $directory_to_ensure = trailingslashit(dirname($relative_path_in_zip));
+            $directory_base = dirname($relative_path_in_zip);
+            $directory_base = is_string($directory_base) ? trim($directory_base) : '';
 
-            if ('' !== $directory_to_ensure && '.' !== $directory_to_ensure) {
-                $segments = explode('/', trim($directory_to_ensure, '/'));
-                $current  = '';
+            if ('' !== $directory_base && '.' !== $directory_base && '/' !== $directory_base && '\\' !== $directory_base) {
+                $directory_to_ensure = trailingslashit($directory_base);
+                $segments = array_filter(
+                    explode('/', trim($directory_to_ensure, '/')),
+                    static function ($segment) {
+                        return '' !== $segment && '.' !== $segment;
+                    }
+                );
 
-                foreach ($segments as $segment) {
-                    $current .= $segment . '/';
-                    if (!isset($directories_added[$current])) {
-                        $zip->add_directory($current);
-                        $directories_added[$current] = true;
+                if (!empty($segments)) {
+                    $current = '';
+
+                    foreach ($segments as $segment) {
+                        $current .= $segment . '/';
+
+                        if (!isset($directories_added[$current])) {
+                            $zip->add_directory($current);
+                            $directories_added[$current] = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- prevent the background export process from enqueueing artificial `./` directories when adding root-level files to an archive
- add a regression test that verifies root-level exports avoid dot-directory entries in the generated ZIP

## Testing
- npm test *(fails: `phpunit: not found` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e64f881a74832ebb64b3fd59d030cf