### PR TITLE
Filter parent directory segments from exclusion patterns

### DIFF
--- a/tests/test-export-sanitization.php
+++ b/tests/test-export-sanitization.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
+
+class Test_Export_Sanitization extends WP_UnitTestCase {
+    public function test_sanitize_exclusion_patterns_discards_parent_directory_segments() {
+        $input = [
+            '../secret',
+            'subdir/../hidden.php',
+            '..\\windows\\style.css',
+            'valid/file.php',
+            'file..backup',
+        ];
+
+        $sanitized = TEJLG_Export::sanitize_exclusion_patterns($input);
+
+        $this->assertContains('valid/file.php', $sanitized, 'Expected valid paths to be preserved.');
+        $this->assertContains('file..backup', $sanitized, 'File names containing double dots should not be treated as traversal attempts.');
+        $this->assertNotContains('../secret', $sanitized, 'Parent directory traversal segments must be removed.');
+        $this->assertNotContains('subdir/../hidden.php', $sanitized, 'Nested traversal segments must be removed.');
+        $this->assertNotContains('..\\windows\\style.css', $sanitized, 'Windows-style traversal patterns must be removed.');
+    }
+}

--- a/theme-export-jlg/includes/class-tejlg-export.php
+++ b/theme-export-jlg/includes/class-tejlg-export.php
@@ -59,6 +59,12 @@ class TEJLG_Export {
                 continue;
             }
 
+            $normalized_for_segments = str_replace('\\', '/', $pattern);
+
+            if (preg_match('#(?:^|/)\.\.(?:/|$)#', $normalized_for_segments)) {
+                continue;
+            }
+
             if ('' === $pattern) {
                 continue;
             }


### PR DESCRIPTION
## Summary
- prevent exclusion patterns containing parent directory segments from being persisted
- add regression coverage ensuring traversal sequences are discarded while legitimate names remain intact

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e66b89a1e0832ebd0e43e0dc393717