### PR TITLE
Extract exclusion pattern sanitization service

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
     <testsuites>
         <testsuite name="Theme Export JLG">
             <file>tests/test-export-process.php</file>
+            <file>tests/test-export-sanitization.php</file>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/test-export-sanitization.php
+++ b/tests/test-export-sanitization.php
@@ -1,8 +1,22 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_check_invalid_utf8')) {
+    function wp_check_invalid_utf8($string) {
+        return (string) $string;
+    }
+}
+
+if (!function_exists('wp_strip_all_tags')) {
+    function wp_strip_all_tags($string) {
+        return strip_tags((string) $string);
+    }
+}
+
 require_once dirname(__DIR__) . '/theme-export-jlg/includes/class-tejlg-export.php';
 
-class Test_Export_Sanitization extends WP_UnitTestCase {
+class Test_Export_Sanitization extends TestCase {
     public function test_sanitize_exclusion_patterns_discards_parent_directory_segments() {
         $input = [
             '../secret',
@@ -19,5 +33,21 @@ class Test_Export_Sanitization extends WP_UnitTestCase {
         $this->assertNotContains('../secret', $sanitized, 'Parent directory traversal segments must be removed.');
         $this->assertNotContains('subdir/../hidden.php', $sanitized, 'Nested traversal segments must be removed.');
         $this->assertNotContains('..\\windows\\style.css', $sanitized, 'Windows-style traversal patterns must be removed.');
+    }
+
+    public function test_exclusion_patterns_sanitizer_limits_count_and_length() {
+        $input = [
+            '  leading/slash  ',
+            '../should-be-removed',
+            str_repeat('a', 400),
+        ];
+
+        $sanitized = TEJLG_Exclusion_Patterns_Sanitizer::sanitize_list($input, 1, 10);
+
+        $this->assertSame(['leading/slash'], $sanitized, 'Expected trimming, traversal removal and maximum count enforcement.');
+
+        $sanitized_string = TEJLG_Exclusion_Patterns_Sanitizer::sanitize_string("foo\nbar", 1, 5);
+
+        $this->assertSame('foo', $sanitized_string, 'Expected newline-separated string to respect max patterns.');
     }
 }

--- a/theme-export-jlg/includes/class-tejlg-exclusion-patterns-sanitizer.php
+++ b/theme-export-jlg/includes/class-tejlg-exclusion-patterns-sanitizer.php
@@ -1,0 +1,130 @@
+<?php
+
+class TEJLG_Exclusion_Patterns_Sanitizer {
+    const DEFAULT_MAX_PATTERNS = 200;
+    const DEFAULT_MAX_PATTERN_LENGTH = 255;
+
+    /**
+     * @param string|array $raw_patterns
+     * @param int|null $max_patterns
+     * @param int|null $max_pattern_length
+     * @return array<int, string>
+     */
+    public static function sanitize_list($raw_patterns, $max_patterns = null, $max_pattern_length = null) {
+        $max_patterns       = self::normalize_positive_int($max_patterns, self::DEFAULT_MAX_PATTERNS);
+        $max_pattern_length = self::normalize_positive_int($max_pattern_length, self::DEFAULT_MAX_PATTERN_LENGTH);
+
+        if (is_string($raw_patterns)) {
+            $candidates = preg_split('/[,\r\n]+/', $raw_patterns);
+        } elseif (is_array($raw_patterns)) {
+            $candidates = $raw_patterns;
+        } else {
+            $candidates = [];
+        }
+
+        if (!is_array($candidates)) {
+            $candidates = [];
+        }
+
+        $sanitized = [];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) || is_object($candidate)) {
+                continue;
+            }
+
+            $pattern = (string) $candidate;
+
+            if (function_exists('wp_check_invalid_utf8')) {
+                $pattern = wp_check_invalid_utf8($pattern, true);
+            }
+
+            if (function_exists('wp_strip_all_tags')) {
+                $pattern = wp_strip_all_tags($pattern);
+            } else {
+                $pattern = strip_tags($pattern);
+            }
+            $pattern = preg_replace('/[\x00-\x1F\x7F]/', '', $pattern);
+
+            if (!is_string($pattern)) {
+                continue;
+            }
+
+            $pattern = trim($pattern);
+            $pattern = preg_replace('#^[\\/]+#', '', $pattern);
+
+            if (!is_string($pattern)) {
+                continue;
+            }
+
+            $normalized_for_segments = str_replace('\\', '/', $pattern);
+
+            if (preg_match('#(?:^|/)\.\.(?:/|$)#', $normalized_for_segments)) {
+                continue;
+            }
+
+            if ('' === $pattern) {
+                continue;
+            }
+
+            if (function_exists('mb_substr')) {
+                $pattern = mb_substr($pattern, 0, $max_pattern_length);
+            } else {
+                $pattern = substr($pattern, 0, $max_pattern_length);
+            }
+
+            if (!is_string($pattern)) {
+                continue;
+            }
+
+            if ('' === $pattern) {
+                continue;
+            }
+
+            if (in_array($pattern, $sanitized, true)) {
+                continue;
+            }
+
+            $sanitized[] = $pattern;
+
+            if (count($sanitized) >= $max_patterns) {
+                break;
+            }
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * @param string|array $raw_patterns
+     * @param int|null     $max_patterns
+     * @param int|null     $max_pattern_length
+     *
+     * @return string
+     */
+    public static function sanitize_string($raw_patterns, $max_patterns = null, $max_pattern_length = null) {
+        $patterns = self::sanitize_list($raw_patterns, $max_patterns, $max_pattern_length);
+
+        if (empty($patterns)) {
+            return '';
+        }
+
+        return implode("\n", $patterns);
+    }
+
+    private static function normalize_positive_int($value, $default) {
+        if (is_int($value) && $value > 0) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            $value = (int) $value;
+
+            if ($value > 0) {
+                return $value;
+            }
+        }
+
+        return $default;
+    }
+}


### PR DESCRIPTION
## Summary
- extract a dedicated `TEJLG_Exclusion_Patterns_Sanitizer` service and delegate exclusion handling to it
- simplify scheduled export exclusion normalization through the new service
- add focused PHPUnit coverage for the sanitizer and include the test in the default suite

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite "Theme Export JLG"

------
https://chatgpt.com/codex/tasks/task_e_68e67049b620832e8bb7e11ab093170d