### PR TITLE
Add code review notes for sanitizer changes

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,9 @@
+# Code Review Notes
+
+## Blocking Issues
+
+- **tests/test-export-sanitization.php**: La fonction factice `wp_check_invalid_utf8()` n'accepte qu'un seul argument, alors que l'implémentation WordPress reçoit un second argument optionnel (`$strip`). L'appel `wp_check_invalid_utf8($pattern, true)` dans `TEJLG_Exclusion_Patterns_Sanitizer::sanitize_list()` va provoquer une erreur fatale pendant les tests. Il faut ajouter le paramètre optionnel pour aligner la signature sur celle de WordPress.
+
+## Recommandations
+
+- Ajuster la signature de l'ersatz `wp_check_invalid_utf8()` pour éviter l'erreur fatale (par exemple `function wp_check_invalid_utf8($string, $strip = false)`).


### PR DESCRIPTION
## Summary
- add a review document noting the fatal error that would occur in the new sanitizer tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6784b4d30832eb6ab87b172ca0c47