### PR TITLE
Fix utf8 stub signature in sanitization tests

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,9 @@
+# Code Review Notes
+
+## Blocking Issues
+
+- **tests/test-export-sanitization.php**: La fonction factice `wp_check_invalid_utf8()` n'accepte qu'un seul argument, alors que l'implémentation WordPress reçoit un second argument optionnel (`$strip`). L'appel `wp_check_invalid_utf8($pattern, true)` dans `TEJLG_Exclusion_Patterns_Sanitizer::sanitize_list()` va provoquer une erreur fatale pendant les tests. Il faut ajouter le paramètre optionnel pour aligner la signature sur celle de WordPress.
+
+## Recommandations
+
+- Ajuster la signature de l'ersatz `wp_check_invalid_utf8()` pour éviter l'erreur fatale (par exemple `function wp_check_invalid_utf8($string, $strip = false)`).

--- a/tests/test-export-sanitization.php
+++ b/tests/test-export-sanitization.php
@@ -3,7 +3,7 @@
 use PHPUnit\Framework\TestCase;
 
 if (!function_exists('wp_check_invalid_utf8')) {
-    function wp_check_invalid_utf8($string) {
+    function wp_check_invalid_utf8($string, $strip = false) {
         return (string) $string;
     }
 }


### PR DESCRIPTION
## Summary
- update the wp_check_invalid_utf8 test stub to accept the optional $strip argument so it matches the WordPress function signature

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68e6784b4d30832eb6ab87b172ca0c47